### PR TITLE
feat: add bakta and roary skills for gene annotation and pan-genome analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SciAgent-Skills
 
 <p align="center">
-  <img src="https://img.shields.io/badge/skills-197-blue?style=for-the-badge" alt="197 Skills">
+  <img src="https://img.shields.io/badge/skills-199-blue?style=for-the-badge" alt="199 Skills">
   <img src="https://img.shields.io/badge/BixBench-92.0%25-brightgreen?style=for-the-badge" alt="BixBench 92.0%">
   <img src="https://img.shields.io/badge/license-CC--BY--4.0-lightgrey?style=for-the-badge" alt="CC-BY-4.0">
   <img src="https://img.shields.io/github/stars/jaechang-hits/SciAgent-Skills?style=for-the-badge" alt="GitHub Stars">
 </p>
 
-> **Turn your AI coding agent into a life sciences expert** — 197 bioinformatics skills for Claude Code covering RNA-seq, single-cell analysis, genomics, proteomics, drug discovery, and more. Boosted [BixBench](https://github.com/Future-House/BixBench) from 65% to 92%. Open source.
+> **Turn your AI coding agent into a life sciences expert** — 199 bioinformatics skills for Claude Code covering RNA-seq, single-cell analysis, genomics, proteomics, drug discovery, and more. Boosted [BixBench](https://github.com/Future-House/BixBench) from 65% to 92%. Open source.
 
 **SciAgent-Skills** is the largest open-source skill library for scientific AI agents. It equips [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (and any markdown-compatible agent) with domain-specific knowledge for computational biology, bioinformatics, cheminformatics, and biostatistics — no fine-tuning required, just plug in and analyze.
 
@@ -36,7 +36,7 @@ Want to try these skills without any setup? **[OmicsHorizon](https://omicshorizo
 
 ---
 
-**197 ready-to-use scientific skills for AI coding agents** — covering genomics, proteomics, drug discovery, biostatistics, scientific computing, and scientific writing.
+**199 ready-to-use scientific skills for AI coding agents** — covering genomics, proteomics, drug discovery, biostatistics, scientific computing, and scientific writing.
 
 Each skill is a self-contained SKILL.md file with runnable code examples, key parameters, troubleshooting guides, and best practices. Designed for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), but compatible with any AI agent that reads markdown skill files ([setup guides below](#using-with-other-agents)).
 
@@ -44,7 +44,7 @@ Each skill is a self-contained SKILL.md file with runnable code examples, key pa
 
 | Category | Skills | Examples |
 |----------|:------:|----------|
-| Genomics & Bioinformatics | 63 | Scanpy, BioPython, pysam, gget, KEGG, PubMed, scvi-tools |
+| Genomics & Bioinformatics | 65 | Scanpy, BioPython, pysam, gget, KEGG, PubMed, scvi-tools, Bakta, Roary |
 | Structural Biology & Drug Discovery | 26 | RDKit, AutoDock Vina, ChEMBL, PDB, DeepChem, datamol |
 | Scientific Computing | 24 | Polars, Dask, NetworkX, SymPy, UMAP, PyG, Zarr, SimPy |
 | Cell Biology | 15 | pydicom, histolab, FlowIO |
@@ -56,7 +56,7 @@ Each skill is a self-contained SKILL.md file with runnable code examples, key pa
 | Data Visualization | 5 | Plotly, Seaborn |
 | Molecular Biology | 3 | CRISPR sgRNA design, gene expression, cloning |
 
-**Skill types:** 72 toolkits, 53 database connectors, 36 guides, 35 pipelines
+**Skill types:** 72 toolkits, 53 database connectors, 37 guides, 37 pipelines
 
 ## Installation
 
@@ -205,7 +205,7 @@ SciAgent-Skills/
 ├── .claude-plugin/
 │   └── plugin.json        # Claude Code plugin manifest
 ├── integration-templates/  # Config templates for Codex, Cursor, Windsurf
-├── skills/                 # All 197 skills organized by category
+├── skills/                 # All 199 skills organized by category
 │   ├── genomics-bioinformatics/
 │   ├── structural-biology-drug-discovery/
 │   ├── scientific-computing/
@@ -285,7 +285,7 @@ Uses: `lamindb-data-management` → `reactome-pathway-analysis` → `string-prot
 
 | Feature | SciAgent-Skills | GPTomics/bioSkills | ClawBio |
 |---------|:-:|:-:|:-:|
-| Total skills | **197** | ~30 | ~20 |
+| Total skills | **199** | ~30 | ~20 |
 | BixBench benchmark | **92.0%** | — | — |
 | Skill types | Pipeline, Toolkit, Database, Guide | Pipeline | Pipeline |
 | Multi-agent support | Claude Code, Codex, Cursor, Windsurf | Claude Code | Claude Code |

--- a/registry.yaml
+++ b/registry.yaml
@@ -1539,3 +1539,19 @@ entries:
     description: "General scientific figure quality checklist for generated plots. Covers visual inspection for overlapping labels, clipped text, missing axes/legends, empty plot areas, overcrowded data, and resolution/format best practices across journals."
     date_added: "2026-04-01"
 
+  - name: "bakta-genome-annotation"
+    type: skill
+    sub_type: pipeline
+    category: "genomics-bioinformatics"
+    path: "skills/genomics-bioinformatics/bakta-genome-annotation/SKILL.md"
+    description: "Annotate bacterial and archaeal genomes and plasmids with Bakta's Prodigal/HMM/DIAMOND pipeline against a curated UniRef-derived database. Identifies CDS, ncRNA, tRNA, rRNA, tmRNA, sORFs, CRISPR arrays, and replication origins. Produces NCBI-compatible GFF3, GenBank, EMBL, FASTA, JSON, TSV, and a circular Circos plot. Use Prokka for legacy pipelines or non-bacterial kingdoms; PGAP for NCBI GenBank submission; Bakta for faster, regularly updated annotation."
+    date_added: "2026-05-08"
+
+  - name: "roary-pangenome"
+    type: skill
+    sub_type: pipeline
+    category: "genomics-bioinformatics"
+    path: "skills/genomics-bioinformatics/roary-pangenome/SKILL.md"
+    description: "Compute the bacterial pan-genome from Prokka/Bakta GFF3 annotations with Roary's CD-HIT + BLASTP + MCL clustering pipeline. Outputs the gene presence/absence matrix, core/soft-core/shell/cloud partitions, a non-redundant pan-genome reference FASTA, and an optional concatenated core-gene alignment for phylogenetics. Use Panaroo for fragmented assemblies or noisy annotations; PIRATE for paralog-aware multi-threshold clustering; PPanGGOLiN for graph-based statistical partitioning."
+    date_added: "2026-05-08"
+

--- a/skills/genomics-bioinformatics/bakta-genome-annotation/SKILL.md
+++ b/skills/genomics-bioinformatics/bakta-genome-annotation/SKILL.md
@@ -1,0 +1,540 @@
+---
+name: "bakta-genome-annotation"
+description: "Annotate bacterial and archaeal genomes and plasmids with Bakta's Prodigal/HMM/diamond pipeline. Identifies CDS, ncRNA, tRNA, rRNA, tmRNA, sORFs, CRISPR arrays, oriC/oriV/oriT, and gaps against a curated UniRef-derived database. Produces NCBI-compatible GFF3, GenBank, EMBL, JSON, FASTA, TSV, and a circular genome plot. Use Prokka for legacy pipelines or non-bacterial kingdoms; PGAP for NCBI GenBank submission."
+license: "GPL-3.0"
+---
+
+# Bakta Genome Annotation
+
+## Overview
+
+Bakta is a command-line pipeline for rapid, standardized annotation of bacterial and archaeal genomes and plasmids. It combines Prodigal for CDS prediction, tRNAscan-SE/Aragorn/Barrnap/Infernal for non-coding RNA, PILER-CR/PILERCR for CRISPR detection, and a tiered DIAMOND/HMM search against a curated UniRef100 + IPS/UPS database to assign gene names, EC numbers, GO terms, and COG categories. Bakta produces NCBI-compatible outputs (GFF3, GenBank, EMBL, INSDC-formatted FASTA, plus a JSON summary and a circular Circos plot) for a typical 5 Mb genome in 5–15 minutes on 8 CPUs.
+
+## When to Use
+
+- Annotating bacterial or archaeal genome assemblies (Illumina, PacBio, Nanopore) with NCBI-compatible locus tags and product names
+- Annotating plasmids and other circular replicons separately with `--plasmid` and `--complete` flags
+- Producing JSON-structured annotation outputs that can be parsed without GenBank or GFF3 detours
+- Generating a publication-ready circular genome plot via the bundled `bakta_plot` command
+- Annotating MAGs (metagenome-assembled genomes) with `--meta` to disable Prodigal training
+- Use **Prokka** instead when you need viral/mitochondrial kingdoms or when you must reproduce a legacy Prokka pipeline exactly
+- Use **PGAP** instead when submitting to NCBI GenBank with full standards compliance
+- Use **Bakta** when you want faster runs, regularly updated UniRef-derived databases, AMRFinderPlus integration, and a JSON summary out of the box
+
+## Prerequisites
+
+- **Software**: Bakta ≥ 1.9, Python 3.8+, Prodigal, tRNAscan-SE, Aragorn, Barrnap, Infernal, DIAMOND, HMMER3, PILER-CR, BLAST+, AMRFinderPlus
+- **Database**: Bakta DB (full ~70 GB, or light ~3 GB) downloaded once with `bakta_db download`
+- **Python packages** (for output parsing): `biopython`, `pandas`, `matplotlib`
+- **Input**: assembled genome in FASTA format (one or more contigs)
+- **Hardware**: ≥ 16 GB RAM for full DB, ≥ 4 GB RAM for light DB; ≥ 8 CPUs recommended
+
+> **Check before installing**: The tool may already be available in the current environment (e.g., inside a `pixi` / `conda` env). Run `command -v bakta` first and skip the install commands below if it returns a path. When running inside a pixi project, invoke the tool via `pixi run bakta` rather than bare `bakta`.
+
+```bash
+# Install Bakta via conda/mamba (recommended)
+mamba install -c conda-forge -c bioconda bakta
+
+# Verify installation
+bakta --version
+# bakta 1.9.4
+
+# Download the light database (~3 GB, faster, fewer functional hits)
+bakta_db download --output db/ --type light
+
+# Or full database (~70 GB, comprehensive UniRef100 coverage)
+# bakta_db download --output db/ --type full
+
+# Install Python parsing dependencies
+pip install biopython pandas matplotlib
+```
+
+## Quick Start
+
+```bash
+# Annotate a bacterial genome — results in results/ directory
+bakta genome.fasta \
+    --db db/bakta_db_light \
+    --output results/ \
+    --prefix sample1 \
+    --threads 8
+
+# Inspect the JSON summary for feature counts
+python -c "
+import json
+with open('results/sample1.json') as f:
+    d = json.load(f)
+print('Genus:', d['genome'].get('genus'))
+print('Length:', d['genome']['size'], 'bp')
+print('CDS:', sum(1 for f in d['features'] if f['type'] == 'cds'))
+print('tRNA:', sum(1 for f in d['features'] if f['type'] == 'tRNA'))
+"
+```
+
+## Workflow
+
+### Step 1: Install Bakta and Download the Database
+
+Install Bakta and prepare the reference database. The database download is one-time and reused across runs.
+
+```bash
+# Create a dedicated conda environment (avoids dependency conflicts)
+mamba create -n bakta_env -c conda-forge -c bioconda bakta python=3.11 -y
+mamba activate bakta_env
+
+# Verify Bakta and its dependencies
+bakta --version
+# bakta 1.9.4
+
+bakta --help | head -20
+
+# Download the light database (sufficient for routine annotation)
+mkdir -p db/
+bakta_db download --output db/ --type light
+# Downloads ~3 GB; expands to ~5 GB on disk
+
+# Verify the database was extracted correctly
+ls db/bakta_db_light/
+# antifam.h3f  bakta.db  expert  oric.fna  pfam.h3f  rfam-go.tsv  ...
+
+# (Optional) Update AMRFinderPlus DB used by Bakta for AMR gene calling
+amrfinder -u
+
+# Install Python parsing tools
+pip install biopython pandas matplotlib
+```
+
+### Step 2: Prepare the Input Assembly
+
+Bakta requires clean FASTA headers without spaces or special characters. Pre-clean and optionally filter short contigs.
+
+```python
+from Bio import SeqIO
+import re
+
+input_fasta = "genome.fasta"
+records = list(SeqIO.parse(input_fasta, "fasta"))
+print(f"Input assembly: {len(records)} contigs")
+total_bases = sum(len(r) for r in records)
+print(f"Total bases: {total_bases:,}")
+print(f"Largest contig: {max(len(r) for r in records):,} bp")
+
+# Bakta preferred: short, alphanumeric, unique IDs
+cleaned = []
+for i, rec in enumerate(records, 1):
+    new_id = f"contig_{i:04d}"
+    new_rec = rec.__class__(rec.seq, id=new_id, description="")
+    cleaned.append(new_rec)
+
+SeqIO.write(cleaned, "genome_clean.fasta", "fasta")
+print(f"Wrote genome_clean.fasta with {len(cleaned)} contigs")
+```
+
+```bash
+# Filter out short contigs (<200 bp) which contribute little to annotation
+awk 'BEGIN{RS=">"; ORS=""} NR>1 {n=split($0, a, "\n"); seq=""; for(i=2;i<=n;i++) seq=seq a[i]; if (length(seq) >= 200) print ">" $0}' \
+    genome_clean.fasta > genome_filtered.fasta
+
+echo "Filtered assembly: $(grep -c '>' genome_filtered.fasta) contigs"
+```
+
+### Step 3: Run Standard Bakta Annotation
+
+Run Bakta with genus/species hints. Locus tags are auto-generated from the strain field.
+
+```bash
+# Standard annotation for a draft bacterial genome
+bakta genome_clean.fasta \
+    --db db/bakta_db_light \
+    --output annotation/ \
+    --prefix E_coli_K12 \
+    --genus Escherichia \
+    --species coli \
+    --strain K12 \
+    --locus-tag ECOLI \
+    --threads 8 \
+    --keep-contig-headers
+
+# Expected runtime: 5–15 min for ~5 Mb genome on 8 CPUs (light DB)
+
+echo "Bakta annotation outputs:"
+ls annotation/
+# E_coli_K12.embl   E_coli_K12.faa     E_coli_K12.ffn
+# E_coli_K12.fna    E_coli_K12.gbff    E_coli_K12.gff3
+# E_coli_K12.hypotheticals.faa  E_coli_K12.hypotheticals.tsv
+# E_coli_K12.json   E_coli_K12.log     E_coli_K12.png
+# E_coli_K12.svg    E_coli_K12.tsv     E_coli_K12.txt
+```
+
+### Step 4: Parse the JSON Summary
+
+Bakta's JSON output is the canonical, machine-readable annotation. Parse it directly for downstream pipelines.
+
+```python
+import json
+import pandas as pd
+from collections import Counter
+
+with open("annotation/E_coli_K12.json") as f:
+    bakta = json.load(f)
+
+# Genome-level metadata
+genome = bakta["genome"]
+print(f"Organism: {genome.get('genus')} {genome.get('species')} {genome.get('strain')}")
+print(f"Size: {genome['size']:,} bp across {len(bakta['sequences'])} sequences")
+print(f"GC content: {genome['gc']:.2%}")
+
+# Feature type counts
+features = bakta["features"]
+type_counts = Counter(f["type"] for f in features)
+print("\nFeature counts:")
+for ftype, n in sorted(type_counts.items(), key=lambda x: -x[1]):
+    print(f"  {ftype:>10}: {n}")
+
+# Build a tidy CDS DataFrame
+cds_rows = []
+for f in features:
+    if f["type"] != "cds":
+        continue
+    cds_rows.append({
+        "locus_tag": f.get("locus", ""),
+        "contig":    f.get("contig", ""),
+        "start":     f.get("start"),
+        "stop":      f.get("stop"),
+        "strand":    f.get("strand"),
+        "gene":      f.get("gene", ""),
+        "product":   f.get("product", ""),
+        "length_aa": len(f.get("aa", "")),
+    })
+
+cds_df = pd.DataFrame(cds_rows)
+print(f"\nTotal CDS: {len(cds_df)}")
+print(cds_df.head(5).to_string(index=False))
+```
+
+### Step 5: Parse the TSV Feature Table
+
+The TSV output is convenient for spreadsheet workflows and quick filtering.
+
+```python
+import pandas as pd
+
+# Bakta TSV begins with comment lines starting with '#'
+df = pd.read_csv("annotation/E_coli_K12.tsv", sep="\t", comment="#",
+                 names=["sequence_id", "type", "start", "stop", "strand",
+                        "locus_tag", "gene", "product", "dbxrefs"])
+print(f"Total features: {len(df)}")
+print(f"Feature types: {df['type'].value_counts().to_dict()}")
+
+# Hypothetical vs annotated CDS
+cds = df[df["type"] == "cds"].copy()
+hypothetical = cds["product"].str.contains("hypothetical", case=False, na=True)
+print(f"\nCDS with assigned function: {(~hypothetical).sum()} / {len(cds)}")
+print(f"Hypothetical proteins: {hypothetical.sum()}")
+
+# Cross-references (UniRef, KEGG, EC, GO, etc.) parsed from the dbxrefs column
+def split_xrefs(xref_str):
+    if not isinstance(xref_str, str) or xref_str in ("", "-"):
+        return []
+    return [x.strip() for x in xref_str.split(",")]
+
+cds["dbxref_list"] = cds["dbxrefs"].apply(split_xrefs)
+ec_hits = cds[cds["dbxref_list"].apply(lambda xs: any(x.startswith("EC:") for x in xs))]
+print(f"CDS with EC numbers: {len(ec_hits)}")
+print(ec_hits[["locus_tag", "gene", "product"]].head(5).to_string(index=False))
+```
+
+### Step 6: Render the Circular Genome Plot
+
+Bakta emits a Circos-style PNG/SVG by default. Regenerate with custom styling using `bakta_plot`.
+
+```bash
+# Re-render the plot from the existing JSON with a different style
+bakta_plot --output annotation/ \
+           --prefix E_coli_K12_replot \
+           --type cog \
+           --dpi 300 \
+           annotation/E_coli_K12.json
+
+ls annotation/E_coli_K12_replot.*
+# E_coli_K12_replot.png  E_coli_K12_replot.svg
+
+# Display the rendered PNG inline in a Jupyter notebook
+python <<'PY'
+from pathlib import Path
+import matplotlib.pyplot as plt
+import matplotlib.image as mpimg
+
+img = mpimg.imread("annotation/E_coli_K12.png")
+fig, ax = plt.subplots(figsize=(6, 6))
+ax.imshow(img)
+ax.axis("off")
+ax.set_title("Bakta circular genome annotation")
+plt.savefig("bakta_circular_thumbnail.png", dpi=120, bbox_inches="tight")
+print("Saved bakta_circular_thumbnail.png")
+PY
+```
+
+### Step 7: Compute Annotation Quality Statistics
+
+Summarize hypothetical-protein rate, gene density, and feature coverage to assess annotation quality.
+
+```python
+import json
+import pandas as pd
+import matplotlib.pyplot as plt
+
+with open("annotation/E_coli_K12.json") as f:
+    bakta = json.load(f)
+
+genome_size = bakta["genome"]["size"]
+features = bakta["features"]
+
+# Per-feature-type counts and density (per Mb)
+counts = {}
+for f in features:
+    counts[f["type"]] = counts.get(f["type"], 0) + 1
+density = {k: v / (genome_size / 1e6) for k, v in counts.items()}
+
+cds = [f for f in features if f["type"] == "cds"]
+n_cds = len(cds)
+n_hypo = sum(1 for f in cds if "hypothetical" in (f.get("product") or "").lower())
+n_known = n_cds - n_hypo
+coding_density = sum(abs(f["stop"] - f["start"] + 1) for f in cds) / genome_size
+
+print(f"Genome: {genome_size:,} bp")
+print(f"CDS: {n_cds}  ({density.get('cds', 0):.1f} per Mb)")
+print(f"  Known function: {n_known}  Hypothetical: {n_hypo}")
+print(f"Coding density: {coding_density:.1%}")
+print(f"tRNA: {counts.get('tRNA', 0)}   rRNA: {counts.get('rRNA', 0)}")
+print(f"ncRNA: {counts.get('ncRNA', 0)}  CRISPR: {counts.get('crispr', 0)}")
+
+# Bar plot of feature type counts
+fig, ax = plt.subplots(figsize=(8, 4))
+items = sorted(counts.items(), key=lambda x: -x[1])
+labels = [k for k, _ in items]
+values = [v for _, v in items]
+bars = ax.bar(labels, values, color="#2980B9", edgecolor="white")
+for bar, v in zip(bars, values):
+    ax.text(bar.get_x() + bar.get_width() / 2, v + max(values) * 0.01,
+            str(v), ha="center", fontsize=9)
+ax.set_ylabel("Count")
+ax.set_title("Bakta feature counts by type")
+plt.xticks(rotation=20)
+plt.tight_layout()
+plt.savefig("bakta_feature_counts.png", dpi=150, bbox_inches="tight")
+print("Saved bakta_feature_counts.png")
+```
+
+### Step 8: Batch Annotation Across Multiple Genomes
+
+Run Bakta over a directory of assemblies and aggregate per-sample summary statistics.
+
+```bash
+#!/bin/bash
+# batch_bakta.sh — annotate all FASTA files in a directory
+INPUT_DIR="genomes/"
+OUTPUT_DIR="annotations/"
+DB="db/bakta_db_light"
+mkdir -p "$OUTPUT_DIR"
+
+for FASTA in "$INPUT_DIR"/*.fasta; do
+    SAMPLE=$(basename "$FASTA" .fasta)
+    echo "Annotating: $SAMPLE"
+    bakta "$FASTA" \
+        --db "$DB" \
+        --output "${OUTPUT_DIR}/${SAMPLE}" \
+        --prefix "$SAMPLE" \
+        --threads 4 \
+        --skip-plot \
+        --force
+done
+
+echo "Batch annotation complete."
+```
+
+```python
+# Aggregate per-genome summaries from each sample's JSON file
+from pathlib import Path
+import json
+import pandas as pd
+
+annotation_dir = Path("annotations/")
+rows = []
+for json_file in sorted(annotation_dir.glob("*/*.json")):
+    with open(json_file) as f:
+        bakta = json.load(f)
+    sample = json_file.stem
+    counts = {}
+    for feat in bakta["features"]:
+        counts[feat["type"]] = counts.get(feat["type"], 0) + 1
+    rows.append({
+        "sample":  sample,
+        "size":    bakta["genome"]["size"],
+        "gc":      bakta["genome"]["gc"],
+        "CDS":     counts.get("cds", 0),
+        "tRNA":    counts.get("tRNA", 0),
+        "rRNA":    counts.get("rRNA", 0),
+        "ncRNA":   counts.get("ncRNA", 0),
+        "crispr":  counts.get("crispr", 0),
+    })
+
+summary_df = pd.DataFrame(rows)
+print(f"Annotated genomes: {len(summary_df)}")
+print(summary_df.to_string(index=False))
+summary_df.to_csv("batch_bakta_summary.csv", index=False)
+print("Saved: batch_bakta_summary.csv")
+```
+
+## Key Parameters
+
+| Parameter | Default | Range / Options | Effect |
+|-----------|---------|-----------------|--------|
+| `--db` | — | path to Bakta DB directory | Required; selects light or full reference DB |
+| `--genus` | — | any genus name string | Sets organism metadata in GenBank/EMBL output |
+| `--species` | — | any species name string | Combined with `--genus` for organism qualifier |
+| `--strain` | — | any string | Adds strain qualifier to organism metadata |
+| `--locus-tag` | auto | 3–24 alphanumeric chars | Prefix for locus tags (e.g., `ECOLI_00001`) |
+| `--complete` | off | flag | Treat all input contigs as complete circular replicons |
+| `--plasmid` | off | flag | Treat all input contigs as plasmids (circular) |
+| `--meta` | off | flag | Disable Prodigal training (use for MAGs / metagenomic bins) |
+| `--translation-table` | `11` | NCBI table IDs (1, 4, 11, 25, …) | Genetic code used by Prodigal for CDS translation |
+| `--min-contig-length` | `1` | any integer (bp) | Skip contigs shorter than this length |
+| `--threads` | `1` | `1`–CPU count | Parallel threads for DIAMOND/HMMER searches |
+| `--skip-plot` | off | flag | Skip the slow circular plot rendering step |
+| `--keep-contig-headers` | off | flag | Preserve original contig IDs instead of renaming |
+| `--proteins` | — | path to GenBank or FASTA file | Custom expert protein DB used before UniRef search |
+
+## Common Recipes
+
+### Recipe: Plasmid-only Annotation
+
+When to use: A finished circular plasmid sequence that should be annotated without chromosome assumptions.
+
+```bash
+bakta plasmid.fasta \
+    --db db/bakta_db_light \
+    --output plasmid_annotation/ \
+    --prefix pBR322 \
+    --plasmid \
+    --complete \
+    --threads 4
+
+# Inspect plasmid-typing results (incompatibility group, replication initiator)
+grep -E "rep|inc" plasmid_annotation/pBR322.tsv | head -10
+```
+
+### Recipe: MAG (Metagenome-Assembled Genome) Annotation
+
+When to use: Annotating a bin from metagenomic assembly where Prodigal cannot train on the full sequence.
+
+```bash
+bakta MAG_bin_42.fasta \
+    --db db/bakta_db_light \
+    --output mag_annotation/ \
+    --prefix MAG_bin_42 \
+    --meta \
+    --min-contig-length 500 \
+    --skip-plot \
+    --threads 8
+
+cat mag_annotation/MAG_bin_42.txt | head -20
+```
+
+### Recipe: Annotation with Custom Expert Protein Database
+
+When to use: You have curated reference proteins (e.g., a virulence factor catalog) that should take priority over UniRef.
+
+```bash
+# Custom proteins are searched before the bundled UniRef DB
+bakta genome.fasta \
+    --db db/bakta_db_light \
+    --proteins virulence_factors.faa \
+    --output annotation_custom/ \
+    --prefix novel_strain \
+    --threads 8
+
+echo "Annotations referencing custom DB:"
+grep "User-provided" annotation_custom/novel_strain.tsv | head
+```
+
+### Recipe: Convert Bakta GFF3 to a Pandas DataFrame
+
+When to use: You need feature coordinates and qualifiers for downstream coordinate-overlap analyses.
+
+```python
+import pandas as pd
+
+def parse_gff3(gff_file):
+    rows = []
+    with open(gff_file) as f:
+        for line in f:
+            if line.startswith("##FASTA"):
+                break
+            if line.startswith("#") or not line.strip():
+                continue
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 9:
+                continue
+            attrs = {}
+            for item in parts[8].split(";"):
+                if "=" in item:
+                    k, v = item.split("=", 1)
+                    attrs[k] = v
+            rows.append({
+                "seqname":   parts[0],
+                "feature":   parts[2],
+                "start":     int(parts[3]),
+                "end":       int(parts[4]),
+                "strand":    parts[6],
+                "locus_tag": attrs.get("locus_tag", attrs.get("ID", "")),
+                "gene":      attrs.get("gene", ""),
+                "product":   attrs.get("product", ""),
+            })
+    return pd.DataFrame(rows)
+
+gff_df = parse_gff3("annotation/E_coli_K12.gff3")
+print(f"Features parsed: {len(gff_df)}")
+print(gff_df[gff_df["feature"] == "CDS"].head(5).to_string(index=False))
+```
+
+## Expected Outputs
+
+| Output File | Format | Description |
+|-------------|--------|-------------|
+| `{prefix}.gff3` | GFF3 | Genome annotation with feature coordinates and attributes; INSDC-compliant |
+| `{prefix}.gbff` | GenBank Flat File | Annotated GenBank record for use in Geneious, BioPython, NCBI submission prep |
+| `{prefix}.embl` | EMBL | EMBL-format annotation for ENA submission |
+| `{prefix}.fna` | FASTA | Nucleotide sequences of the input contigs |
+| `{prefix}.ffn` | FASTA | Nucleotide sequences of all annotated features |
+| `{prefix}.faa` | FASTA | Protein sequences for all CDS features |
+| `{prefix}.hypotheticals.faa` | FASTA | Protein sequences flagged as hypothetical (for further investigation) |
+| `{prefix}.hypotheticals.tsv` | TSV | Detailed table for hypothetical CDS with low-confidence hits |
+| `{prefix}.tsv` | TSV | Full feature table: seqid, type, start, stop, strand, locus_tag, gene, product, dbxrefs |
+| `{prefix}.json` | JSON | Machine-readable summary with genome metadata + every feature with full qualifiers |
+| `{prefix}.png` / `.svg` | Image | Circos circular genome plot colored by COG category |
+| `{prefix}.txt` | Text | Plain-text summary of feature counts and per-replicon stats |
+| `{prefix}.log` | Text | Full Bakta run log including timing per step |
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `Error: database not found at <path>` | DB path incorrect, or DB not extracted | Re-run `bakta_db download --output db/ --type light`; pass full path to `--db` |
+| `KILLED` during DIAMOND step | Out of memory on full DB | Switch to `--type light`, reduce `--threads`, or run on a host with ≥ 32 GB RAM |
+| Very high hypothetical-protein rate (>60 %) | Divergent strain or light DB without close hits | Re-run with the full DB or supply a curated `--proteins` reference set |
+| `tRNAscan-SE: Error opening file` | Missing tRNAscan-SE installation in conda env | `mamba install -c bioconda trnascan-se` and rerun |
+| Bakta complains about contig headers | Spaces or special characters in FASTA IDs | Pre-clean headers with `awk '/^>/{print ">contig_"++i; next}{print}'` |
+| Plot generation hangs or fails | Circos / matplotlib backend issue | Re-run with `--skip-plot`; render later via `bakta_plot` from the JSON file |
+| `AMRFinderPlus: database not up-to-date` warning | AMRFinderPlus DB stale | `amrfinder -u` to refresh, or pass `--skip-amr` to bypass |
+| Different locus tag prefix than expected | `--locus-tag` not set, default uses random prefix | Explicitly pass `--locus-tag MYORG` to control prefix |
+| Run is much slower than reported | Default `--threads 1` | Set `--threads` to physical core count; use `--skip-plot` for batch jobs |
+
+## References
+
+- [Bakta GitHub: oschwengers/bakta](https://github.com/oschwengers/bakta) — source code, installation, parameter reference, and changelog
+- [Schwengers et al. (2021) Microb Genom 7(11):000685](https://doi.org/10.1099/mgen.0.000685) — original Bakta publication with benchmarks vs. Prokka and PGAP
+- [Bakta database releases on Zenodo](https://doi.org/10.5281/zenodo.4247252) — versioned light/full database archives
+- [Prodigal documentation](https://github.com/hyattpd/Prodigal/wiki) — gene prediction engine used by Bakta for CDS calling
+- [BioPython GenBank parsing tutorial](https://biopython.org/wiki/SeqIO) — reference for parsing Bakta `.gbff` output in Python
+- [DIAMOND aligner](https://github.com/bbuchfink/diamond) — protein search engine used for the UniRef-derived database lookups

--- a/skills/genomics-bioinformatics/roary-pangenome/SKILL.md
+++ b/skills/genomics-bioinformatics/roary-pangenome/SKILL.md
@@ -1,0 +1,486 @@
+---
+name: "roary-pangenome"
+description: "Compute the bacterial pan-genome from Prokka/Bakta GFF3 annotations with Roary's CD-HIT + BLAST + MCL clustering pipeline. Builds gene presence/absence matrices, core/soft-core/shell/cloud partitions, multi-FASTA core gene alignments (with `-e`), and a pan-genome reference. Use Panaroo for higher-accuracy pan-genomes from highly fragmented assemblies, PIRATE for paralog-aware clustering, or PPanGGOLiN for graph-based partitioning."
+license: "GPL-3.0"
+---
+
+# Roary Pan-Genome Pipeline
+
+## Overview
+
+Roary is a high-throughput pan-genome pipeline for prokaryotes that takes per-sample GFF3 annotations (typically from Prokka or Bakta) and produces a clustered gene presence/absence matrix across the entire input set. It first reduces redundancy with CD-HIT iterative clustering, then performs an all-vs-all BLASTP within each pre-cluster, and finally applies MCL graph clustering to define orthologous gene families. The output partitions the gene space into core (≥ 99 %), soft-core (95–99 %), shell (15–95 %), and cloud (< 15 %) genes and optionally builds a concatenated core-gene alignment suitable for phylogenetic inference.
+
+## When to Use
+
+- Computing a pan-genome from a set of bacterial isolate annotations (10–10,000 genomes)
+- Producing a `gene_presence_absence.csv` matrix for downstream GWAS, accessory-gene mining, or core-gene phylogenetics
+- Building a concatenated core-gene multi-FASTA alignment for ML/Bayesian phylogenetic trees
+- Generating a pan-genome reference FASTA to use as a non-redundant gene catalog
+- Comparative genomics across closely related strains where >95 % nucleotide identity is expected
+- Use **Panaroo** instead when assemblies are highly fragmented or annotations are noisy (Panaroo aggressively cleans annotation errors)
+- Use **PIRATE** instead when paralog-aware clustering with multiple identity thresholds is needed
+- Use **PPanGGOLiN** instead when graph-based, statistically grounded gene-family partitioning is preferred over fixed-frequency cutoffs
+
+## Prerequisites
+
+- **Software**: Roary ≥ 3.13, Perl 5, BLAST+, CD-HIT, MCL, BEDTools, PRANK or MAFFT (for `-e` core alignment), FastTree (optional)
+- **Python packages** (for output parsing): `pandas`, `matplotlib`, `seaborn`, `biopython`, `dendropy`
+- **Input**: per-sample GFF3 files with embedded FASTA at the end (Prokka/Bakta default output)
+- **Hardware**: ≥ 8 GB RAM for ~50 genomes; 32 GB+ recommended for ~500 genomes
+- **Naming**: each GFF3 filename becomes the sample column header in the output matrix; use `sample_id.gff` style
+
+> **Check before installing**: The tool may already be available in the current environment (e.g., inside a `pixi` / `conda` env). Run `command -v roary` first and skip the install commands below if it returns a path. When running inside a pixi project, invoke the tool via `pixi run roary` rather than bare `roary`.
+
+```bash
+# Install Roary via conda/mamba (recommended)
+mamba install -c conda-forge -c bioconda roary
+
+# Verify installation
+roary --version
+# 3.13.0
+
+# Verify dependent tools
+which cd-hit blastp mcl bedtools mafft
+# /opt/conda/bin/cd-hit
+# /opt/conda/bin/blastp
+# /opt/conda/bin/mcl
+# /opt/conda/bin/bedtools
+# /opt/conda/bin/mafft
+
+# Install Python parsing dependencies
+pip install pandas matplotlib seaborn biopython dendropy
+```
+
+## Quick Start
+
+```bash
+# Run Roary on all GFF3 files in current directory; emit core gene alignment
+roary -e --mafft -p 8 -o pangenome -f roary_out/ *.gff
+
+# Inspect summary statistics
+cat roary_out/summary_statistics.txt
+# Core genes        (99% <= strains <= 100%) 2823
+# Soft core genes   (95% <= strains <  99%)   78
+# Shell genes       (15% <= strains <  95%)  1542
+# Cloud genes       ( 0% <= strains <  15%)  3104
+# Total genes                                 7547
+```
+
+## Workflow
+
+### Step 1: Install Roary and Verify Dependencies
+
+Install Roary in a dedicated environment to avoid Perl module conflicts.
+
+```bash
+# Create a dedicated conda environment
+mamba create -n roary_env -c conda-forge -c bioconda roary mafft fasttree python=3.11 -y
+mamba activate roary_env
+
+# Verify Roary
+roary --version
+# 3.13.0
+
+# Confirm pipeline dependencies are reachable
+for tool in cd-hit blastp mcl bedtools mafft FastTree; do
+    if command -v $tool >/dev/null; then
+        echo "OK: $tool"
+    else
+        echo "MISSING: $tool"
+    fi
+done
+
+# Install Python parsing tools
+pip install pandas matplotlib seaborn biopython dendropy
+```
+
+### Step 2: Prepare Per-Sample GFF3 Files from Prokka or Bakta
+
+Roary requires GFF3 files with an embedded FASTA section (the `##FASTA` block). Both Prokka `.gff` and Bakta `.gff3` outputs satisfy this format.
+
+```bash
+# Verify GFF3 files include the embedded FASTA section
+mkdir -p roary_input/
+cp annotations/*/sample*.gff roary_input/
+
+for GFF in roary_input/*.gff; do
+    if grep -q "^##FASTA" "$GFF"; then
+        echo "OK: $GFF"
+    else
+        echo "MISSING ##FASTA in: $GFF"
+    fi
+done
+
+# Roary uses GFF filename (without .gff) as the sample column name.
+# Rename or symlink to ensure unique, descriptive names.
+cd roary_input/
+ls *.gff | head
+# strain_A.gff  strain_B.gff  strain_C.gff
+```
+
+```python
+# Sanity-check sample size and unique names
+from pathlib import Path
+
+gff_files = sorted(Path("roary_input/").glob("*.gff"))
+print(f"GFF files: {len(gff_files)}")
+
+names = [g.stem for g in gff_files]
+duplicates = [n for n in names if names.count(n) > 1]
+assert not duplicates, f"Duplicate sample names: {set(duplicates)}"
+
+# Show first 5
+for g in gff_files[:5]:
+    size_mb = g.stat().st_size / 1e6
+    print(f"  {g.name}: {size_mb:.1f} MB")
+```
+
+### Step 3: Run Roary with Core Gene Alignment
+
+The `-e --mafft` combination produces the concatenated core-gene alignment used downstream for phylogenetics.
+
+```bash
+# Run Roary on the prepared GFF directory
+# -e: extract core gene alignment per gene, then concatenate
+# --mafft: use MAFFT for alignment (faster than default PRANK)
+# -p 8: 8 parallel processes
+# -i 95: min BLASTP percentage identity (default 95)
+# -cd 99: % isolates a gene must be in to be "core" (default 99)
+roary -e --mafft \
+    -p 8 \
+    -i 95 \
+    -cd 99 \
+    -o pangenome \
+    -f roary_out/ \
+    roary_input/*.gff
+
+# Expected runtime:
+#   ~50 genomes:  10–20 min
+#   ~500 genomes: 4–8 hours
+
+ls roary_out/
+# accessory_binary_genes.fa            gene_presence_absence.csv
+# accessory_binary_genes.fa.newick     gene_presence_absence.Rtab
+# accessory.header.embl                number_of_conserved_genes.Rtab
+# accessory.tab                        number_of_genes_in_pan_genome.Rtab
+# blast_identity_frequency.Rtab        number_of_new_genes.Rtab
+# clustered_proteins                   number_of_unique_genes.Rtab
+# core_accessory.header.embl           pan_genome_reference.fa
+# core_accessory.tab                   summary_statistics.txt
+# core_gene_alignment.aln
+```
+
+### Step 4: Parse the Gene Presence/Absence Matrix
+
+The CSV output is the canonical pan-genome matrix: rows are gene families, columns include metadata and one column per sample (filled with locus tags or empty).
+
+```python
+import pandas as pd
+import numpy as np
+
+df = pd.read_csv("roary_out/gene_presence_absence.csv", low_memory=False)
+print(f"Gene families: {len(df)}")
+print(f"Columns: {len(df.columns)}")
+# Standard metadata columns end with 'Inference', then sample columns follow
+metadata_cols = list(df.columns[:14])
+sample_cols = list(df.columns[14:])
+print(f"Samples: {len(sample_cols)}")
+
+# Build a binary presence/absence matrix (1 = locus tag present, 0 = empty)
+binary = df[sample_cols].notna().astype(int)
+binary.index = df["Gene"]
+print(f"Binary matrix shape: {binary.shape}")
+
+# Pan-genome partition by frequency
+n_samples = len(sample_cols)
+freq = binary.sum(axis=1) / n_samples
+core      = freq[freq >= 0.99]
+soft_core = freq[(freq >= 0.95) & (freq < 0.99)]
+shell     = freq[(freq >= 0.15) & (freq < 0.95)]
+cloud     = freq[freq < 0.15]
+
+print(f"\nPan-genome partition (n={n_samples} genomes):")
+print(f"  Core      (>=99 %): {len(core):>5}")
+print(f"  Soft-core (95–99 %): {len(soft_core):>5}")
+print(f"  Shell    (15–95 %): {len(shell):>5}")
+print(f"  Cloud      (<15 %): {len(cloud):>5}")
+print(f"  Total            : {len(freq):>5}")
+```
+
+### Step 5: Visualize the Pan-Genome Frequency Distribution
+
+A frequency histogram exposes whether the input set has a U-shaped (open) or core-skewed (closed) pan-genome.
+
+```python
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+
+df = pd.read_csv("roary_out/gene_presence_absence.csv", low_memory=False)
+sample_cols = list(df.columns[14:])
+n = len(sample_cols)
+binary = df[sample_cols].notna().astype(int)
+freq = binary.sum(axis=1)
+
+fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+
+# Histogram of gene frequencies
+axes[0].hist(freq, bins=range(1, n + 2), color="#2980B9", edgecolor="white")
+axes[0].axvline(0.99 * n, color="red", linestyle="--", label="99 % core cutoff")
+axes[0].axvline(0.15 * n, color="orange", linestyle="--", label="15 % shell cutoff")
+axes[0].set_xlabel("Number of genomes containing the gene")
+axes[0].set_ylabel("Number of gene families")
+axes[0].set_title("Pan-genome frequency distribution")
+axes[0].legend()
+
+# Pie chart of pan-genome partition
+freqp = freq / n
+core_n      = (freqp >= 0.99).sum()
+soft_n      = ((freqp >= 0.95) & (freqp < 0.99)).sum()
+shell_n     = ((freqp >= 0.15) & (freqp < 0.95)).sum()
+cloud_n     = (freqp < 0.15).sum()
+axes[1].pie([core_n, soft_n, shell_n, cloud_n],
+            labels=[f"Core ({core_n})", f"Soft-core ({soft_n})",
+                    f"Shell ({shell_n})", f"Cloud ({cloud_n})"],
+            colors=["#27AE60", "#3498DB", "#F39C12", "#95A5A6"],
+            autopct="%1.1f%%", startangle=90)
+axes[1].set_title(f"Pan-genome partition (n={n} genomes)")
+
+plt.tight_layout()
+plt.savefig("pangenome_distribution.png", dpi=150, bbox_inches="tight")
+print(f"Saved pangenome_distribution.png  (total families: {len(freq)})")
+```
+
+### Step 6: Build a Phylogenetic Tree from the Core Gene Alignment
+
+Use FastTree on the concatenated core-gene alignment to recover strain relationships.
+
+```bash
+# FastTree expects an aligned multi-FASTA; Roary produces this with `-e`
+FastTree -nt -gtr -nosupport \
+    < roary_out/core_gene_alignment.aln \
+    > roary_out/core_gene_tree.nwk
+
+echo "Tree built: roary_out/core_gene_tree.nwk"
+# (Optional) IQ-TREE for support values:
+# iqtree -s core_gene_alignment.aln -m GTR+G -bb 1000 -nt 8
+```
+
+```python
+# Visualize the FastTree result alongside the gene presence/absence matrix
+import dendropy
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+
+tree = dendropy.Tree.get(path="roary_out/core_gene_tree.nwk", schema="newick")
+leaves = [leaf.taxon.label for leaf in tree.leaf_node_iter()]
+print(f"Tree leaves: {len(leaves)}")
+print(f"Tree length: {tree.length():.4f} substitutions/site")
+
+# Print first 10 leaves with their root-to-tip distances
+for leaf in list(tree.leaf_node_iter())[:10]:
+    dist = leaf.distance_from_root()
+    print(f"  {leaf.taxon.label:<25}  d={dist:.4f}")
+```
+
+### Step 7: Produce Roary's Built-in Summary Plots
+
+Roary ships with a `roary_plots.py` companion that builds a tree-anchored matrix figure.
+
+```bash
+# Use the bundled python helper from the Roary install
+# (download from: https://github.com/sanger-pathogens/Roary/blob/master/contrib/roary_plots/roary_plots.py)
+python roary_plots.py \
+    roary_out/core_gene_tree.nwk \
+    roary_out/gene_presence_absence.csv \
+    --format png \
+    --labels
+
+ls *.png
+# pangenome_frequency.png
+# pangenome_matrix.png
+# pangenome_pie.png
+```
+
+### Step 8: Compute Per-Genome Accessory Gene Counts
+
+Identify which genomes carry the most unique (cloud) genes — useful for strain-specific gene investigation.
+
+```python
+import pandas as pd
+
+df = pd.read_csv("roary_out/gene_presence_absence.csv", low_memory=False)
+sample_cols = list(df.columns[14:])
+n = len(sample_cols)
+binary = df[sample_cols].notna().astype(int)
+binary.index = df["Gene"]
+
+freq = binary.sum(axis=1)
+cloud_mask = freq < (0.15 * n)
+shell_mask = (freq >= 0.15 * n) & (freq < 0.95 * n)
+
+per_genome = pd.DataFrame({
+    "genes_total":   binary.sum(axis=0),
+    "cloud_genes":   binary.loc[cloud_mask].sum(axis=0),
+    "shell_genes":   binary.loc[shell_mask].sum(axis=0),
+})
+per_genome = per_genome.sort_values("cloud_genes", ascending=False)
+print(per_genome.head(10).to_string())
+
+per_genome.to_csv("per_genome_accessory_counts.csv")
+print("\nSaved per_genome_accessory_counts.csv")
+```
+
+## Key Parameters
+
+| Parameter | Default | Range / Options | Effect |
+|-----------|---------|-----------------|--------|
+| `-i` | `95` | `70`–`99` (% identity) | Minimum BLASTP percentage identity for clustering |
+| `-cd` | `99` | `90`–`100` (%) | Minimum % of isolates a gene must be in to be called "core" |
+| `-p` | `1` | `1`–CPU count | Number of parallel processes for BLAST and MCL stages |
+| `-e` | off | flag | Extract concatenated core gene multi-FASTA alignment (per-gene MSA + concat) |
+| `--mafft` | off | flag (with `-e`) | Use MAFFT for alignment (faster than default PRANK) |
+| `-s` | off | flag | Do not split paralogs into separate gene families |
+| `-n` | off | flag | Use fast core gene alignment with MAFFT (skips per-gene PRANK) |
+| `-g` | `50000` | any integer | Maximum number of clusters expected (cap on output size) |
+| `-iv` | `1.5` | `1.2`–`5.0` | MCL inflation value; higher = tighter clusters |
+| `-r` | off | flag | Generate R plots (presence/absence heatmap, pan-genome curves) |
+| `-o` | `clustered_proteins` | string | Output prefix for clustered proteins file |
+| `-f` | `.` | path | Output directory |
+| `-z` | off | flag | Don't delete intermediate files (useful for debugging) |
+
+## Common Recipes
+
+### Recipe: Core Gene Alignment from Existing Roary Output
+
+When to use: You already ran Roary without `-e` and now need a phylogenetic alignment.
+
+```bash
+# Re-run only the alignment step using the extracted core genes
+# query_pan_genome from the Roary suite extracts gene-family multi-FASTAs
+query_pan_genome -a intersection \
+    -g roary_out/clustered_proteins \
+    -o core_gene_list.txt \
+    roary_input/*.gff
+
+echo "Core genes: $(wc -l < core_gene_list.txt)"
+# Then re-run Roary with -e to materialize the alignment:
+# roary -e --mafft -p 8 -f roary_out2/ roary_input/*.gff
+```
+
+### Recipe: Lower Identity Threshold for Diverse Genus-Level Sets
+
+When to use: Comparing genomes across multiple closely related species (e.g., genus-level pan-genome).
+
+```bash
+# Drop identity to 70 % to capture orthologs across species boundaries
+roary -e --mafft \
+    -p 8 \
+    -i 70 \
+    -cd 99 \
+    -f roary_genus/ \
+    roary_input/*.gff
+
+cat roary_genus/summary_statistics.txt
+# Expect a smaller core and a much larger shell + cloud
+```
+
+### Recipe: Roary on a Subset of Strains
+
+When to use: You want a pan-genome of a specific subclade without re-annotating all genomes.
+
+```bash
+# Stage GFF files for the subset
+mkdir -p subset/
+for SAMPLE in strain_A strain_B strain_E strain_K; do
+    cp roary_input/${SAMPLE}.gff subset/
+done
+
+roary -e --mafft -p 4 -f roary_subset/ subset/*.gff
+echo "Subset pan-genome:"
+cat roary_subset/summary_statistics.txt
+```
+
+### Recipe: Cross-Tabulate Accessory Genes Against Strain Metadata
+
+When to use: You want to find genes enriched in a specific phenotype or geographic group.
+
+```python
+import pandas as pd
+from scipy.stats import fisher_exact
+
+# Load presence/absence and strain metadata
+pa = pd.read_csv("roary_out/gene_presence_absence.csv", low_memory=False)
+sample_cols = list(pa.columns[14:])
+binary = pa[sample_cols].notna().astype(int)
+binary.index = pa["Gene"]
+binary.columns = sample_cols
+
+# Metadata: sample_id, phenotype (e.g., "resistant" / "susceptible")
+meta = pd.read_csv("strain_metadata.csv").set_index("sample_id")
+group_resistant = meta[meta["phenotype"] == "resistant"].index
+group_susceptible = meta[meta["phenotype"] == "susceptible"].index
+group_resistant = [g for g in group_resistant if g in binary.columns]
+group_susceptible = [g for g in group_susceptible if g in binary.columns]
+
+# Fisher's exact test per gene family
+results = []
+for gene, row in binary.iterrows():
+    a = int(row[group_resistant].sum())
+    b = len(group_resistant) - a
+    c = int(row[group_susceptible].sum())
+    d = len(group_susceptible) - c
+    if a + c == 0 or a + c == len(group_resistant) + len(group_susceptible):
+        continue  # skip invariant genes
+    odds, pval = fisher_exact([[a, b], [c, d]])
+    results.append({"gene": gene, "n_resistant": a, "n_susceptible": c,
+                    "odds_ratio": odds, "pvalue": pval})
+
+results_df = pd.DataFrame(results).sort_values("pvalue")
+print(f"Gene-phenotype associations (top 10):")
+print(results_df.head(10).to_string(index=False))
+results_df.to_csv("phenotype_associated_genes.csv", index=False)
+```
+
+## Expected Outputs
+
+| Output File | Format | Description |
+|-------------|--------|-------------|
+| `gene_presence_absence.csv` | CSV | Pan-genome matrix; rows = gene families, columns = sample locus tags |
+| `gene_presence_absence.Rtab` | TSV | Binary 0/1 matrix in R-friendly format |
+| `summary_statistics.txt` | Text | Counts of core / soft-core / shell / cloud / total gene families |
+| `pan_genome_reference.fa` | FASTA | Non-redundant nucleotide reference of one representative per gene family |
+| `clustered_proteins` | Text | Cluster definitions: cluster name → constituent locus tags |
+| `core_gene_alignment.aln` | FASTA (aligned) | Concatenated multi-FASTA of core gene alignments (only with `-e`) |
+| `accessory_binary_genes.fa` | FASTA | Binary 0/1 sequences of accessory presence (input to FastTree) |
+| `accessory_binary_genes.fa.newick` | Newick | Accessory gene phylogeny (built from binary FASTA) |
+| `number_of_conserved_genes.Rtab` | TSV | Rarefaction curve of core genes vs. genome count |
+| `number_of_genes_in_pan_genome.Rtab` | TSV | Rarefaction curve of pan-genome growth |
+| `number_of_new_genes.Rtab` | TSV | New genes added per genome |
+| `number_of_unique_genes.Rtab` | TSV | Per-genome unique gene counts |
+| `blast_identity_frequency.Rtab` | TSV | Distribution of BLAST identities used during clustering |
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `GFF file does not contain ##FASTA` | Annotation file is not a Prokka/Bakta-style GFF3 with embedded sequences | Re-export from Prokka/Bakta; do not strip the FASTA tail |
+| `Could not run blastp` | BLAST+ missing from the conda env | `mamba install -c bioconda blast` and re-activate the env |
+| Roary produces 0 core genes | One sample has very different annotations or is misidentified | Inspect `gene_presence_absence.csv`; remove outlier with `roary --check_input` style sanity checks |
+| Job runs out of memory on > 200 genomes | Default identity (95 %) creates many BLAST jobs | Increase `-i` to 90 if accuracy permits; split into batches; use Panaroo on RAM-tight machines |
+| Paralogs split into many tiny clusters | MCL inflation too high or duplicate locus tags across samples | Add `-s` to keep paralogs together, or rerun Prokka/Bakta with unique `--locus-tag` per sample |
+| `FastTree: bad alignment` on `core_gene_alignment.aln` | Alignment built with PRANK was truncated | Re-run with `--mafft` for MAFFT-based alignment |
+| Output column names look mangled or missing | GFF filenames had spaces or special characters | Rename input GFFs to `[a-zA-Z0-9_]+.gff` before running |
+| Same genome counted twice | Duplicate GFF filenames (e.g., copied symlinks) | Run `ls roary_input/*.gff | sort -u` to confirm unique filenames |
+| Pan-genome size grows linearly without saturation | Truly open pan-genome (expected for many bacteria) | This is biological, not a bug; report rarefaction curves and use Heaps' law for confirmation |
+
+## References
+
+- [Roary GitHub: sanger-pathogens/Roary](https://github.com/sanger-pathogens/Roary) — source code, parameter reference, and roary_plots.py helper
+- [Page et al. (2015) Bioinformatics 31(22):3691–3693](https://doi.org/10.1093/bioinformatics/btv421) — original Roary publication describing the CD-HIT + MCL pipeline
+- [Roary tutorial](https://sanger-pathogens.github.io/Roary/) — step-by-step worked example with sample data
+- [Panaroo (alternative tool)](https://github.com/gtonkinhill/panaroo) — graph-based pan-genome with stricter annotation cleaning
+- [PIRATE (alternative tool)](https://github.com/SionBayliss/PIRATE) — paralog-aware pan-genome at multiple identity thresholds
+- [PPanGGOLiN (alternative tool)](https://github.com/labgem/PPanGGOLiN) — graph-based statistical partitioning of pan-genomes
+- [FastTree documentation](http://www.microbesonline.org/fasttree/) — reference for ML phylogenetic inference from core gene alignments


### PR DESCRIPTION
## Summary

Adds two pipeline skills to `genomics-bioinformatics/` to cover the prokaryotic gene-annotation → pan-genome-clustering workflow that was previously missing from the registry:

- **`bakta-genome-annotation`** — bacterial/archaeal genome and plasmid annotation via Prodigal/HMM/DIAMOND against a curated UniRef-derived database. Covers light/full DB setup, JSON/TSV/GFF3 parsing, Circos plot rendering, MAG and plasmid modes. 8 workflow steps, 4 recipes.
- **`roary-pangenome`** — bacterial pan-genome computation from Prokka/Bakta GFF3 via CD-HIT + BLASTP + MCL. Covers presence/absence parsing, core/soft-core/shell/cloud partitioning, core-gene alignment for phylogenetics, and a Fisher-exact phenotype-association recipe. 8 workflow steps, 4 recipes.

Both skills cross-reference each other and existing `prokka-genome-annotation` / PGAP / Panaroo / PIRATE / PPanGGOLiN entries for routing guidance.

Registry: 197 → 199 entries.

## Checklist

- [x] `pixi run test` passes locally (4135 passed, 0 failed)
- [x] `registry.yaml` updated with the new entry
- [x] Skill type is correctly set: pipeline / toolkit / database / guide
- [x] `description` field is ≤ 1024 characters
- [x] Frontmatter has `name`, `description`, `license`
- [x] Required sections present in correct order (see `CLAUDE.md`)
- [x] Code blocks are runnable with sample data or clear placeholders
- [x] Troubleshooting table has 5+ rows
- [x] Key Parameters table has 5+ rows

## Skill(s) added or modified

- `skills/genomics-bioinformatics/bakta-genome-annotation/SKILL.md` (new)
- `skills/genomics-bioinformatics/roary-pangenome/SKILL.md` (new)
- `registry.yaml` (modified — appended two entries)