### PR TITLE
feat: add omnipath and pypath skills for biological knowledge-graph queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SciAgent-Skills
 
 <p align="center">
-  <img src="https://img.shields.io/badge/skills-199-blue?style=for-the-badge" alt="199 Skills">
+  <img src="https://img.shields.io/badge/skills-201-blue?style=for-the-badge" alt="201 Skills">
   <img src="https://img.shields.io/badge/BixBench-92.0%25-brightgreen?style=for-the-badge" alt="BixBench 92.0%">
   <img src="https://img.shields.io/badge/license-CC--BY--4.0-lightgrey?style=for-the-badge" alt="CC-BY-4.0">
   <img src="https://img.shields.io/github/stars/jaechang-hits/SciAgent-Skills?style=for-the-badge" alt="GitHub Stars">
 </p>
 
-> **Turn your AI coding agent into a life sciences expert** — 199 bioinformatics skills for Claude Code covering RNA-seq, single-cell analysis, genomics, proteomics, drug discovery, and more. Boosted [BixBench](https://github.com/Future-House/BixBench) from 65% to 92%. Open source.
+> **Turn your AI coding agent into a life sciences expert** — 201 bioinformatics skills for Claude Code covering RNA-seq, single-cell analysis, genomics, proteomics, drug discovery, and more. Boosted [BixBench](https://github.com/Future-House/BixBench) from 65% to 92%. Open source.
 
 **SciAgent-Skills** is the largest open-source skill library for scientific AI agents. It equips [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (and any markdown-compatible agent) with domain-specific knowledge for computational biology, bioinformatics, cheminformatics, and biostatistics — no fine-tuning required, just plug in and analyze.
 
@@ -36,7 +36,7 @@ Want to try these skills without any setup? **[OmicsHorizon](https://omicshorizo
 
 ---
 
-**199 ready-to-use scientific skills for AI coding agents** — covering genomics, proteomics, drug discovery, biostatistics, scientific computing, and scientific writing.
+**201 ready-to-use scientific skills for AI coding agents** — covering genomics, proteomics, drug discovery, biostatistics, scientific computing, and scientific writing.
 
 Each skill is a self-contained SKILL.md file with runnable code examples, key parameters, troubleshooting guides, and best practices. Designed for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), but compatible with any AI agent that reads markdown skill files ([setup guides below](#using-with-other-agents)).
 
@@ -50,13 +50,13 @@ Each skill is a self-contained SKILL.md file with runnable code examples, key pa
 | Cell Biology | 15 | pydicom, histolab, FlowIO |
 | Biostatistics | 12 | scikit-learn, statsmodels, PyMC, SHAP, survival analysis |
 | Scientific Writing | 21 | Manuscript writing, peer review, LaTeX posters, slides, figure guides |
-| Systems Biology & Multi-omics | 11 | COBRApy, LaminDB, Reactome, STRING |
+| Systems Biology & Multi-omics | 13 | COBRApy, LaminDB, Reactome, STRING, OmniPath, pypath |
 | Proteomics & Protein Engineering | 10 | ESM, UniProt, PyOpenMS, matchms, HMDB |
 | Lab Automation | 6 | Opentrons, Benchling |
 | Data Visualization | 5 | Plotly, Seaborn |
 | Molecular Biology | 3 | CRISPR sgRNA design, gene expression, cloning |
 
-**Skill types:** 72 toolkits, 53 database connectors, 37 guides, 37 pipelines
+**Skill types:** 73 toolkits, 54 database connectors, 37 guides, 37 pipelines
 
 ## Installation
 
@@ -205,7 +205,7 @@ SciAgent-Skills/
 ├── .claude-plugin/
 │   └── plugin.json        # Claude Code plugin manifest
 ├── integration-templates/  # Config templates for Codex, Cursor, Windsurf
-├── skills/                 # All 199 skills organized by category
+├── skills/                 # All 201 skills organized by category
 │   ├── genomics-bioinformatics/
 │   ├── structural-biology-drug-discovery/
 │   ├── scientific-computing/
@@ -285,7 +285,7 @@ Uses: `lamindb-data-management` → `reactome-pathway-analysis` → `string-prot
 
 | Feature | SciAgent-Skills | GPTomics/bioSkills | ClawBio |
 |---------|:-:|:-:|:-:|
-| Total skills | **199** | ~30 | ~20 |
+| Total skills | **201** | ~30 | ~20 |
 | BixBench benchmark | **92.0%** | — | — |
 | Skill types | Pipeline, Toolkit, Database, Guide | Pipeline | Pipeline |
 | Multi-agent support | Claude Code, Codex, Cursor, Windsurf | Claude Code | Claude Code |

--- a/registry.yaml
+++ b/registry.yaml
@@ -1555,3 +1555,19 @@ entries:
     description: "Compute the bacterial pan-genome from Prokka/Bakta GFF3 annotations with Roary's CD-HIT + BLASTP + MCL clustering pipeline. Outputs the gene presence/absence matrix, core/soft-core/shell/cloud partitions, a non-redundant pan-genome reference FASTA, and an optional concatenated core-gene alignment for phylogenetics. Use Panaroo for fragmented assemblies or noisy annotations; PIRATE for paralog-aware multi-threshold clustering; PPanGGOLiN for graph-based statistical partitioning."
     date_added: "2026-05-08"
 
+  - name: "omnipath-knowledge-graph"
+    type: skill
+    sub_type: database
+    category: "systems-biology-multiomics"
+    path: "skills/systems-biology-multiomics/omnipath-knowledge-graph/SKILL.md"
+    description: "Query the OmniPath integrated biological knowledge graph from Python. The `omnipath` client wraps the saezlab OmniPath web service which integrates 150+ resources covering signaling interactions, transcriptional regulation (DoRothEA, CollecTRI), miRNA-target, post-translational modifications (enzyme-substrate), protein complexes, intercellular communication (ligand-receptor), and entity annotations. All requests return tidy pandas DataFrames. Use `pypath-network-builder` instead when you need to rebuild OmniPath from primary resources or add custom databases; use `string-database-ppi` for STRING-only protein interactions; use `reactome-database` for Reactome pathways."
+    date_added: "2026-05-08"
+
+  - name: "pypath-network-builder"
+    type: skill
+    sub_type: toolkit
+    category: "systems-biology-multiomics"
+    path: "skills/systems-biology-multiomics/pypath-network-builder/SKILL.md"
+    description: "Build customized biological knowledge graphs with pypath — the saezlab Python framework that powers OmniPath. Provides ~150 input modules for individual signaling, regulatory, complex, PTM, annotation, and intercellular databases, plus high-level Network/Annotation/Complex/Enz_sub/Intercell aggregator classes that merge raw inputs and de-duplicate evidence. Includes ID translation utilities, persistent on-disk cache, and pickle-backed snapshots. Use `omnipath-knowledge-graph` instead when you only need to query the existing OmniPath service via its REST API."
+    date_added: "2026-05-08"
+

--- a/skills/systems-biology-multiomics/omnipath-knowledge-graph/SKILL.md
+++ b/skills/systems-biology-multiomics/omnipath-knowledge-graph/SKILL.md
@@ -1,0 +1,494 @@
+---
+name: "omnipath-knowledge-graph"
+description: "Query the OmniPath integrated biological knowledge graph from Python. The `omnipath` client wraps the saezlab OmniPath web service which integrates 150+ resources covering signaling interactions, transcriptional regulation (DoRothEA, CollecTRI), miRNA-target, post-translational modifications (enzyme-substrate), protein complexes, intercellular communication (ligand-receptor), and entity annotations. All requests return tidy pandas DataFrames. Use `pypath-network-builder` instead when you need to rebuild OmniPath from primary resources or add custom databases; use `string-database-ppi` for STRING-only protein interactions; use `reactome-database` for Reactome pathways."
+license: "MIT"
+---
+
+# OmniPath Knowledge Graph Client
+
+## Overview
+
+`omnipath` is a Python client for the OmniPath web service — an integrated knowledge graph maintained by the Saez Lab that combines 150+ literature-curated resources into a unified API. A single import gives access to signed, directed, evidence-tracked interactions (signaling, transcriptional, post-translational, miRNA, lncRNA), enzyme-substrate relationships, protein complex compositions, intercellular communication categories (ligand, receptor, ECM, transporter), and ~5 million functional annotations spanning subcellular localization, function, disease, and pathway membership. Every request returns a pandas DataFrame and respects per-resource license restrictions (academic vs. commercial).
+
+## When to Use
+
+- Pulling a literature-curated signaling network around a target protein or pathway and writing it to NetworkX or a graph database
+- Retrieving ligand-receptor pairs to seed cell-cell communication analyses (CellChat, CellPhoneDB, LIANA inputs)
+- Querying enzyme-substrate (kinase-substrate / phosphatase-substrate) pairs for PTM analysis
+- Mapping a list of genes to subcellular localization, function, pathway, or disease annotations from OmniPath's `Annotations` database
+- Filtering networks by license (`academic` vs. `commercial`) before redistribution
+- Looking up TF-target or miRNA-target relationships for regulatory network construction
+- Use `pypath-network-builder` instead when you need to rebuild OmniPath from raw input modules or add custom resources
+- Use `string-database-ppi` instead for STRING-specific PPI queries with confidence scores; use `reactome-database` for Reactome pathway hierarchy
+
+## Prerequisites
+
+- **Python packages**: `omnipath`, `pandas`, `networkx`, `requests`
+- **Network access**: HTTPS access to `https://omnipathdb.org/`
+- **Cache**: omnipath caches responses by default to `~/.cache/omnipathdb/`; clear with `op.clear_cache()`
+- **Rate limits**: no hard rate limit but be polite (≤ a few requests/sec); large queries return tens of MB so prefer filtered requests over `AllInteractions().get()` without filters
+
+```bash
+pip install omnipath pandas networkx
+```
+
+## Quick Start
+
+```python
+import omnipath as op
+
+# Pull the curated signaling network for human (largest filtered subset)
+net = op.interactions.OmniPath.get(
+    organism="human",
+    genesymbols=True,
+    fields=["sources", "references", "curation_effort"],
+)
+print(f"Edges: {len(net):,}   Unique proteins: {net['source_genesymbol'].nunique() + net['target_genesymbol'].nunique():,}")
+print(net[["source_genesymbol", "target_genesymbol", "is_directed", "is_stimulation", "curation_effort"]].head())
+```
+
+## Core API
+
+### Module 1: Interactions — Signaling, TF-target, miRNA, PTM
+
+The `omnipath.interactions` module exposes one class per interaction dataset. All classes share `.get()`, `.params()`, and `.resources()` helpers.
+
+```python
+import omnipath as op
+
+# Curated signed/directed signaling (the canonical "OmniPath" subset)
+signaling = op.interactions.OmniPath.get(
+    organism="human",
+    genesymbols=True,
+    directed=True,
+    signed=True,
+)
+print(f"Signaling edges: {len(signaling)}")
+print(signaling.columns.tolist())
+
+# All datasets in one query (signaling + TF + miRNA + lncRNA + ...)
+all_int = op.interactions.AllInteractions.get(
+    organism="human",
+    genesymbols=True,
+    datasets=["omnipath", "pathwayextra", "kinaseextra", "ligrecextra"],
+)
+print(f"All-interactions union: {len(all_int):,}")
+```
+
+```python
+# Transcriptional regulation: DoRothEA + CollecTRI via Transcriptional class
+tf = op.interactions.Transcriptional.get(
+    organism="human",
+    genesymbols=True,
+    dorothea_levels=["A", "B", "C"],   # confidence A is highest
+)
+print(f"TF -> target edges: {len(tf):,}")
+print(tf[["source_genesymbol", "target_genesymbol", "dorothea_level"]].head())
+
+# miRNA-target interactions
+mi = op.interactions.miRNA.get(organism="human", genesymbols=True)
+print(f"miRNA -> mRNA edges: {len(mi):,}")
+```
+
+### Module 2: Enzyme-Substrate (PTMs)
+
+Kinase-substrate, phosphatase-substrate, and other enzyme-PTM relationships at residue resolution.
+
+```python
+import omnipath as op
+
+ptm = op.requests.Enzsub.get(
+    organism="human",
+    genesymbols=True,
+)
+print(f"PTM relationships: {len(ptm):,}")
+print(ptm[["enzyme_genesymbol", "substrate_genesymbol",
+           "residue_type", "residue_offset", "modification"]].head())
+
+# Filter to kinase phosphorylation events on a target substrate
+egfr_ptm = ptm[(ptm["substrate_genesymbol"] == "EGFR") &
+               (ptm["modification"] == "phosphorylation")]
+print(f"EGFR phosphosites: {len(egfr_ptm)}")
+print(egfr_ptm[["enzyme_genesymbol", "residue_type", "residue_offset"]].to_string(index=False))
+```
+
+### Module 3: Protein Complexes
+
+Curated protein complex compositions (pre-merged across CORUM, Compleat, ComplexPortal, hu.MAP, Signor, PDB, etc.).
+
+```python
+import omnipath as op
+
+complexes = op.requests.Complexes.get()
+print(f"Complexes: {len(complexes):,}")
+print(complexes.columns.tolist())
+# ['name', 'stoichiometry', 'components_genesymbols', 'sources', 'references', ...]
+
+# Find every complex containing a given subunit
+target = "TP53"
+target_complexes = complexes[complexes["components_genesymbols"].fillna("").str.contains(target)]
+print(f"Complexes containing {target}: {len(target_complexes)}")
+print(target_complexes[["name", "components_genesymbols", "sources"]].head().to_string(index=False))
+```
+
+### Module 4: Annotations — Function, Localization, Pathway, Disease
+
+The Annotations database integrates ~50 resources into a long-format table of `record_id, uniprot, source, label, value`.
+
+```python
+import omnipath as op
+
+# Pull annotations from a single resource (filtered queries are much faster)
+sig_paths = op.requests.Annotations.get(
+    resources=["SignaLink_pathway"],
+    genesymbols=True,
+)
+print(f"SignaLink pathway annotations: {len(sig_paths):,}")
+print(sig_paths.head())
+
+# Pivot into a wide gene x label matrix
+wide = (
+    sig_paths.assign(present=1)
+    .pivot_table(index="genesymbol", columns="label", values="present",
+                 aggfunc="max", fill_value=0)
+)
+print(f"Wide annotation matrix shape: {wide.shape}")
+```
+
+```python
+# Annotations for a specific gene set (UniProt accessions or gene symbols)
+genes = ["EGFR", "ERBB2", "KRAS", "BRAF", "MAP2K1"]
+annot = op.requests.Annotations.get(
+    proteins=genes,
+    resources=["HPA_subcellular", "Compartments", "DisGeNet"],
+    genesymbols=True,
+)
+print(f"Records returned: {len(annot)}")
+print(annot[["genesymbol", "source", "label", "value"]].head(10).to_string(index=False))
+```
+
+### Module 5: Intercell — Ligand-Receptor and Cell-Cell Communication
+
+The Intercell database categorizes proteins into intercellular roles (`ligand`, `receptor`, `adhesion`, `ecm`, `transporter`, ...). Combine with interactions to build a ligand-receptor network.
+
+```python
+import omnipath as op
+
+# Per-protein intercell category labels
+icell = op.requests.Intercell.get(
+    aspect="functional",
+    scope="generic",
+    categories=["ligand", "receptor"],
+)
+print(f"Intercell records: {len(icell):,}")
+print(icell.head()[["uniprot", "genesymbol", "category", "parent", "source"]])
+
+# Pre-built ligand-receptor network (intercell categories joined to OmniPath edges)
+lr = op.interactions.import_intercell_network(
+    transmitter_params={"categories": ["ligand"]},
+    receiver_params={"categories": ["receptor"]},
+)
+print(f"Ligand -> receptor edges: {len(lr):,}")
+print(lr[["source_genesymbol", "target_genesymbol",
+          "category_intercell_source", "category_intercell_target"]].head())
+```
+
+### Module 6: Resource Catalog and Global Options
+
+Discover datasets, organisms, and licenses; control caching and HTTP timeouts.
+
+```python
+import omnipath as op
+
+# Enumerate available interaction datasets
+print("Datasets:", [d.value for d in op.constants.InteractionDataset])
+# ['omnipath', 'pathwayextra', 'kinaseextra', 'ligrecextra', 'dorothea',
+#  'tf_target', 'collectri', 'mirnatarget', 'tf_mirna', 'lncrna_mrna', 'small_molecule']
+
+# Supported organisms
+print("Organisms:", [o.value for o in op.constants.Organism])
+
+# License filter (academic == include all; commercial == only commercial-friendly resources)
+commercial_only = op.interactions.OmniPath.get(license="commercial", organism="human")
+academic = op.interactions.OmniPath.get(license="academic", organism="human")
+print(f"academic: {len(academic):>5}  commercial: {len(commercial_only):>5}")
+```
+
+```python
+# Configure global options
+op.options.timeout = 60                    # seconds
+op.options.num_retries = 3
+op.options.cache  # current cache backend (FileCache by default)
+
+# Resources contributing to a particular dataset
+print("Resources behind OmniPath core:", op.interactions.OmniPath.resources()[:10])
+
+# Wipe the local response cache (useful after server-side updates)
+op.clear_cache()
+```
+
+## Key Concepts
+
+### Field Reference
+
+| Column | Meaning |
+|--------|---------|
+| `source` / `target` | UniProt IDs of the interacting proteins |
+| `source_genesymbol` / `target_genesymbol` | Gene symbol shortcuts (require `genesymbols=True`) |
+| `is_directed` | Whether direction is known (1) or undirected (0) |
+| `is_stimulation` / `is_inhibition` | Sign of the directed edge |
+| `consensus_direction` / `consensus_stimulation` / `consensus_inhibition` | Majority vote across resources |
+| `dorothea_level` | A–E, where A is highest curation confidence |
+| `references` | `pmid:12345;pmid:67890` semicolon-joined evidence list |
+| `sources` | Resources reporting the edge (semicolon-joined) |
+| `curation_effort` | Number of literature references supporting the edge |
+| `n_references` / `n_resources` | Counts of supporting evidence |
+
+### Dataset Cheat Sheet
+
+| Dataset | Class | Coverage |
+|---------|-------|----------|
+| `omnipath` | `OmniPath` | Signed, directed signaling (the curated core) |
+| `pathwayextra` | `PathwayExtra` | Additional activity-flow signaling (less stringent) |
+| `kinaseextra` | `KinaseExtra` | Extra kinase-substrate edges from PTM resources |
+| `ligrecextra` | `LigRecExtra` | Additional ligand-receptor edges |
+| `dorothea` | `Dorothea` | Literature-curated TF-target with A–E confidence |
+| `tf_target` | `TFtarget` | Pooled TF-target (DoRothEA + CollecTRI + others) |
+| `mirnatarget` | `miRNA` | miRNA-mRNA targeting |
+| `lncrna_mrna` | `lncRNAmRNA` | lncRNA-mRNA regulation |
+
+## Common Workflows
+
+### Workflow 1: Build a Signaling Subnetwork around a Gene Set
+
+```python
+import omnipath as op
+import networkx as nx
+import pandas as pd
+
+genes = {"EGFR", "ERBB2", "KRAS", "BRAF", "MAP2K1", "MAPK1", "MYC"}
+
+# Pull all curated signaling, then filter to edges with both endpoints in the seed set
+edges = op.interactions.OmniPath.get(
+    organism="human",
+    genesymbols=True,
+    directed=True,
+)
+sub = edges[edges["source_genesymbol"].isin(genes) &
+            edges["target_genesymbol"].isin(genes)]
+print(f"Subnetwork edges: {len(sub)}")
+
+# Build a directed multigraph; tag edges with sign and curation effort
+G = nx.DiGraph()
+for _, r in sub.iterrows():
+    G.add_edge(
+        r["source_genesymbol"], r["target_genesymbol"],
+        sign=("+" if r["is_stimulation"] else
+              "-" if r["is_inhibition"] else "?"),
+        n_refs=r.get("n_references", 0),
+        sources=r["sources"],
+    )
+print(f"Graph: {G.number_of_nodes()} nodes / {G.number_of_edges()} edges")
+print("Top hubs by out-degree:",
+      sorted(G.out_degree, key=lambda x: -x[1])[:5])
+```
+
+### Workflow 2: Ligand-Receptor Pairs for Cell-Cell Communication
+
+```python
+import omnipath as op
+
+# Materialize the integrated ligand -> receptor edges with downstream signaling enabled
+lr = op.interactions.import_intercell_network(
+    transmitter_params={"categories": ["ligand"], "scope": "generic"},
+    receiver_params={"categories": ["receptor"], "scope": "generic"},
+)
+
+# Keep edges with at least one literature reference
+lr_high = lr[lr["n_references"].fillna(0) >= 1].copy()
+print(f"High-confidence LR pairs: {len(lr_high):,}")
+
+# Build a tidy LR table for downstream tools (CellPhoneDB / LIANA / CellChat input)
+lr_table = (
+    lr_high[["source_genesymbol", "target_genesymbol",
+             "is_stimulation", "is_inhibition", "n_references", "sources"]]
+    .rename(columns={"source_genesymbol": "ligand",
+                     "target_genesymbol": "receptor"})
+    .drop_duplicates(["ligand", "receptor"])
+)
+lr_table.to_csv("omnipath_lr_pairs.tsv", sep="\t", index=False)
+print("Saved omnipath_lr_pairs.tsv")
+```
+
+### Workflow 3: Kinase-Substrate Phosphosite Map for a Pathway
+
+```python
+import omnipath as op
+import pandas as pd
+
+# Genes in the MAPK cascade
+mapk = {"EGFR", "GRB2", "SOS1", "HRAS", "KRAS", "RAF1", "BRAF",
+        "MAP2K1", "MAP2K2", "MAPK1", "MAPK3"}
+
+ptm = op.requests.Enzsub.get(organism="human", genesymbols=True)
+mapk_ptm = ptm[ptm["substrate_genesymbol"].isin(mapk)
+               & (ptm["modification"] == "phosphorylation")]
+print(f"Phosphosites on MAPK proteins: {len(mapk_ptm)}")
+
+# Per-substrate phosphosite count and the kinases targeting it
+summary = (
+    mapk_ptm.groupby("substrate_genesymbol")
+            .agg(n_sites=("residue_offset", "nunique"),
+                 kinases=("enzyme_genesymbol", lambda s: ",".join(sorted(set(s)))))
+            .sort_values("n_sites", ascending=False)
+)
+print(summary.to_string())
+```
+
+### Workflow 4: Annotate a Differentially-Expressed Gene List
+
+```python
+import omnipath as op
+import pandas as pd
+
+degs = pd.read_csv("deseq2_results.csv")
+sig = degs.query("padj < 0.05 and abs(log2FoldChange) > 1")["gene"].tolist()
+
+annot = op.requests.Annotations.get(
+    proteins=sig,
+    resources=["SignaLink_pathway", "HPA_subcellular", "DisGeNet", "MSigDB"],
+    genesymbols=True,
+)
+print(f"Annotations retrieved: {len(annot):,}")
+
+# Most enriched pathway labels among up-regulated DEGs
+pathway_hits = (
+    annot[annot["source"] == "SignaLink_pathway"]
+    .groupby("label").size()
+    .sort_values(ascending=False)
+    .head(10)
+)
+print("Top SignaLink pathways:")
+print(pathway_hits.to_string())
+```
+
+## Key Parameters
+
+| Parameter | Module | Default | Range / Options | Effect |
+|-----------|--------|---------|-----------------|--------|
+| `organism` | all | `"human"` | `"human"`, `"mouse"`, `"rat"` | Species-specific results (mapped via orthology where supported) |
+| `genesymbols` | interactions, enzsub, intercell | `False` | `True` / `False` | Adds `*_genesymbol` columns alongside UniProt IDs |
+| `license` | all | `"academic"` | `"academic"`, `"commercial"`, `"for_profit"` | Drops resources whose license forbids the chosen redistribution mode |
+| `datasets` | `AllInteractions` | all | subset of `InteractionDataset` enum | Restricts the union to the chosen interaction layers |
+| `dorothea_levels` | `Dorothea`, `Transcriptional` | `["A","B","C","D"]` | any subset of `A`–`E` | Confidence cutoff for TF-target interactions (A is highest) |
+| `directed` | interactions | `False` | `True` / `False` | Keep only directed edges |
+| `signed` | interactions | `False` | `True` / `False` | Keep only edges with known stimulation/inhibition |
+| `fields` | interactions | minimal | list of column names | Request additional output columns (e.g., `references`, `curation_effort`) |
+| `resources` | annotations, intercell | all | list of resource names | Restricts to the named source databases |
+| `proteins` | annotations | none | list of UniProt or gene symbols | Limits the query to a gene set (much faster than full pulls) |
+| `categories` | intercell | none | list of category labels | E.g., `["ligand"]`, `["receptor"]`, `["ecm"]` |
+| `scope` | intercell | `"generic"` | `"generic"`, `"specific"` | Granularity of the intercell category hierarchy |
+
+## Common Recipes
+
+### Recipe: Save a Network as GraphML for Cytoscape
+
+When to use: hand off an OmniPath subnetwork to Cytoscape, Gephi, or yEd for visualization.
+
+```python
+import omnipath as op
+import networkx as nx
+
+edges = op.interactions.OmniPath.get(organism="human", genesymbols=True, directed=True)
+G = nx.from_pandas_edgelist(
+    edges, source="source_genesymbol", target="target_genesymbol",
+    edge_attr=["is_stimulation", "is_inhibition", "n_references", "sources"],
+    create_using=nx.DiGraph,
+)
+nx.write_graphml(G, "omnipath_signaling.graphml")
+print(f"Wrote omnipath_signaling.graphml ({G.number_of_nodes()} nodes, {G.number_of_edges()} edges)")
+```
+
+### Recipe: Materialize a Reusable Local Snapshot
+
+When to use: make repeated downstream analyses fast and reproducible by pinning to a specific OmniPath snapshot.
+
+```python
+import omnipath as op
+import pandas as pd
+from pathlib import Path
+
+snap = Path("omnipath_snapshot/")
+snap.mkdir(exist_ok=True)
+
+op.interactions.OmniPath.get(organism="human", genesymbols=True).to_parquet(snap / "signaling.parquet")
+op.requests.Enzsub.get(organism="human", genesymbols=True).to_parquet(snap / "enzsub.parquet")
+op.requests.Complexes.get().to_parquet(snap / "complexes.parquet")
+op.requests.Intercell.get(scope="generic").to_parquet(snap / "intercell.parquet")
+print("Snapshot files:", [p.name for p in snap.glob("*.parquet")])
+```
+
+### Recipe: Filter to Highly-Curated Edges Only
+
+When to use: reduce noise from low-evidence edges before downstream perturbation modeling.
+
+```python
+import omnipath as op
+
+edges = op.interactions.OmniPath.get(
+    organism="human",
+    genesymbols=True,
+    fields=["curation_effort", "references", "sources"],
+)
+# Keep edges with ≥3 supporting publications and ≥2 independent resources
+strong = edges[(edges["curation_effort"] >= 3) &
+               (edges["sources"].str.count(";") >= 1)]
+print(f"Strong edges: {len(strong):,} of {len(edges):,}")
+```
+
+### Recipe: Cache Inspection and Manual Cleanup
+
+When to use: free disk or force a refresh after a server-side database update.
+
+```python
+import omnipath as op
+from pathlib import Path
+
+cache_dir = Path(op.options.cache.path)
+print(f"Cache: {cache_dir}")
+total = sum(p.stat().st_size for p in cache_dir.rglob("*") if p.is_file())
+print(f"Cache size: {total / 1e6:.1f} MB across {sum(1 for _ in cache_dir.rglob('*'))} entries")
+
+# Wipe and re-pull (next request will hit the server)
+op.clear_cache()
+print("Cache cleared.")
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `requests.exceptions.ReadTimeout` on first call | Default timeout too short for very large downloads | Increase `op.options.timeout = 120` and retry |
+| Empty DataFrame from `Annotations.get()` | Forgot `proteins=...` or `resources=...`; full DB query is too large | Always filter by `proteins` or `resources`; the unfiltered pull is ~5 M rows |
+| `KeyError: 'genesymbol'` | Forgot `genesymbols=True` | Re-run with `genesymbols=True`; default returns UniProt IDs only |
+| Different result counts between sessions | OmniPath releases roll forward; cached responses are stale | Run `op.clear_cache()` and re-issue the query |
+| `commercial` license drops most edges | Many sources are academic-only (KEGG, SignaLink, ...) | Confirm license requirement; otherwise stay on `academic` |
+| Network too dense to plot | Default OmniPath core is ~80 k edges | Filter by `curation_effort`, `n_references`, or restrict to a gene set |
+| `import_intercell_network` returns ~M edges | Generic-scope ligand x receptor cross-product is large | Restrict transmitter and receiver `categories` and `scope` |
+| Mouse organism returns very few rows | Resource-by-resource species coverage varies | Combine `organism="mouse"` with `dorothea_levels=["A","B","C"]` and check `pypath-network-builder` for orthology pre-builds |
+
+## Related Skills
+
+- [`pypath-network-builder`](../pypath-network-builder/SKILL.md) — build OmniPath itself, integrate custom resources, fine-grained control beyond what the web service exposes
+- [`string-database-ppi`](../string-database-ppi/SKILL.md) — alternative for STRING-only PPI with confidence scores and species coverage
+- [`reactome-database`](../reactome-database/SKILL.md) — alternative for Reactome pathway hierarchy and enrichment
+- [`cellchat-cell-communication`](../cellchat-cell-communication/SKILL.md) — downstream consumer of OmniPath ligand-receptor pairs
+
+## References
+
+- [omnipath GitHub: saezlab/omnipath](https://github.com/saezlab/omnipath) — Python client source code and issue tracker
+- [omnipath documentation](https://omnipath.readthedocs.io/) — full API reference and examples
+- [OmniPath web service: omnipathdb.org](https://omnipathdb.org/) — REST endpoints, dataset catalog, and license matrix
+- [Türei et al. (2021) Mol Syst Biol 17(3):e9923](https://doi.org/10.15252/msb.20209923) — primary OmniPath publication
+- [Türei et al. (2016) Nat Methods 13:966–967](https://doi.org/10.1038/nmeth.4077) — original OmniPath signaling resource
+- [DoRothEA TF regulons (Garcia-Alonso et al. 2019)](https://doi.org/10.1101/gr.240663.118) — TF-target confidence levels exposed via `Dorothea`

--- a/skills/systems-biology-multiomics/pypath-network-builder/SKILL.md
+++ b/skills/systems-biology-multiomics/pypath-network-builder/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: "pypath-network-builder"
+description: "Build customized biological knowledge graphs with pypath — the saezlab Python framework that powers OmniPath. Provides ~150 input modules for individual signaling, regulatory, complex, PTM, annotation, and intercellular databases (SIGNOR, SignaLink, KEGG, Reactome, DoRothEA, CollecTRI, CORUM, ComplexPortal, hu.MAP, Compleat, HMDB, RaMP, dbPTM, Phospho.ELM, ...), plus high-level Network/Annotation/Complex/Enz_sub/Intercell aggregator classes that merge the raw inputs and de-duplicate evidence. Includes ID translation utilities, a persistent on-disk cache, and pickle-backed snapshots. Use `omnipath-knowledge-graph` instead when you only need to query the existing OmniPath service via its REST API."
+license: "GPL-3.0"
+---
+
+# pypath — OmniPath Network Builder
+
+## Overview
+
+`pypath` is the Python framework that builds OmniPath. It loads, normalizes, and integrates ~150 primary biological resources into unified Network, Annotation, Complex, Enzyme-Substrate, and Intercellular databases. Where the lightweight `omnipath` client only queries the pre-built web service, `pypath` operates on the raw input modules — letting you add custom resources, swap ID systems, change merging rules, restrict to specific organisms, or rebuild a private OmniPath snapshot. It also provides reusable utilities: a curl-based caching layer, ID-mapping tables across UniProt/Ensembl/Entrez/HGNC/MGI/MIRBase/RefSeq, and a settings/context system for download timeouts and debug logging.
+
+## When to Use
+
+- Rebuilding OmniPath from primary resources to lock in a reproducible snapshot for a publication
+- Loading individual input modules (`pypath.inputs.signor`, `pypath.inputs.kegg`, ...) without going through the integrated database
+- Integrating a custom or in-house resource into a Network alongside OmniPath inputs
+- Translating identifiers between UniProt, Ensembl, Entrez, HGNC, MGI, RefSeq, miRBase, and chemical IDs (KEGG, ChEBI, HMDB, InChI, SMILES) at scale
+- Inspecting per-resource evidence on individual interactions, complexes, or PTMs
+- Querying the integrated databases offline from cached pickles after an initial build
+- Use `omnipath-knowledge-graph` instead when you only need to query the public OmniPath REST API and do not need to rebuild or extend it
+- Use `string-database-ppi` instead when you only need STRING PPI; use `reactome-database` for Reactome pathway hierarchies
+
+## Prerequisites
+
+- **Python packages**: `pypath-omnipath`, `pandas`, `numpy`, `requests`, `lxml`, `pycurl`, `python-igraph`
+- **System**: ≥ 8 GB RAM (more for full builds), ≥ 50 GB free disk for cache + pickles on a complete build
+- **Network access**: outbound HTTPS to many primary resource websites (saezlab mirrors many of them but some are upstream)
+- **Cache**: `~/.pypath/cache/` (raw downloads), `~/.pypath/pickles/` (built database snapshots) by default
+
+```bash
+pip install pypath-omnipath pandas python-igraph
+```
+
+> **Performance note**: First-time builds of large databases can take 30–90 minutes because pypath downloads from dozens of upstream resources. Subsequent loads use cached pickles and complete in seconds.
+
+## Quick Start
+
+```python
+from pypath.core import network
+from pypath.resources import network as netres
+
+# Build a literature-curated activity-flow network (the curated subset of OmniPath)
+n = network.Network()
+n.load(netres.pathway)                # core literature-curated signaling
+n.load(netres.enzyme_substrate)       # add kinase/phosphatase-substrate relationships
+print(f"Nodes: {n.vcount}   Edges: {n.ecount}")
+
+# Inspect a single interaction
+ia = next(iter(n.interactions.values()))
+print(ia)
+```
+
+## Core API
+
+### Module 1: `pypath.core.network` — The Network Class
+
+The `Network` class is the central aggregator. Resources are added via `load()` and can be queried, exported, or pickled.
+
+```python
+from pypath.core import network
+from pypath.resources import network as netres
+
+n = network.Network()
+n.load(netres.pathway)
+n.load(netres.transcription_dorothea, only_directions=True)
+
+# Iterate over interactions and inspect evidence per resource
+for ia in list(n.interactions.values())[:3]:
+    print(ia.a.label, "->", ia.b.label,
+          "  resources:", [str(e) for e in ia.evidences][:3])
+
+# Filter to a subgraph by gene symbols
+seed = {"EGFR", "KRAS", "BRAF", "MAP2K1", "MAPK1"}
+sub = [ia for ia in n.interactions.values()
+       if ia.a.label in seed and ia.b.label in seed]
+print(f"Seed-induced subgraph: {len(sub)} edges")
+```
+
+```python
+# Export to a tidy pandas DataFrame and save as Parquet
+df = n.records()
+print(df.shape, df.columns.tolist()[:8])
+
+df.to_parquet("network.parquet")
+print("Saved network.parquet")
+
+# Pickle the whole Network for fast reload
+n.save_to_pickle("network.pkl")
+n2 = network.Network.from_pickle("network.pkl")
+print(f"Reloaded: {n2.vcount} nodes / {n2.ecount} edges")
+```
+
+### Module 2: Resource Presets — `pypath.resources.network`
+
+`pypath.resources.network` ships pre-defined collections of resources covering common analytical layers, so you do not need to assemble them manually.
+
+```python
+from pypath.resources import network as netres
+
+# Available presets (each is a dict of {resource_name: ResourceDefinition})
+print("Pathway resources:", sorted(netres.pathway)[:8])
+print("Transcription presets:", sorted(netres.transcription))
+print("PTM resources:", sorted(netres.enzyme_substrate)[:8])
+
+# Single-resource pulls — only SIGNOR, only SignaLink, only KEGG, ...
+from pypath.core import network
+n = network.Network()
+n.load(netres.pathway["SIGNOR"])
+print(f"SIGNOR-only network: {n.vcount} nodes / {n.ecount} edges")
+```
+
+### Module 3: Input Modules — `pypath.inputs.*`
+
+Each primary resource has its own input module exposing per-resource loaders that return raw or lightly-normalized records (lists of named tuples or DataFrames).
+
+```python
+from pypath.inputs import signor, kegg, dorothea
+
+# SIGNOR signaling interactions, complexes, and enzyme-substrate
+signor_int = signor.signor_interactions()
+print(f"SIGNOR raw interactions: {len(signor_int)}")
+print(signor_int[0])
+
+complexes = signor.signor_complexes()
+print(f"SIGNOR complexes: {len(complexes)}")
+
+enz = signor.signor_enzyme_substrate()
+print(f"SIGNOR enzyme-substrate: {len(enz)}")
+```
+
+```python
+from pypath.inputs import collectri, hmdb
+
+# CollecTRI TF-target collection
+ctri = collectri.collectri_interactions()
+print(f"CollecTRI TF-target rows: {len(ctri)}")
+print(ctri[0])
+
+# HMDB metabolite metadata
+metabolites = hmdb.metabolites_table("accession", "name", "smiles", head=5)
+print(metabolites)
+```
+
+### Module 4: Annotations / Complexes / Enz_sub / Intercell Aggregators
+
+Each integrated database has its own `core` module that pre-merges all input resources and deduplicates evidence.
+
+```python
+from pypath.core import annot, complex as cplx, enz_sub, intercell
+
+# Build (or load from pickle) the annotation database
+an = annot.AnnotationTable()
+print(f"Annotation records: {len(an)}")
+
+# Protein complex aggregator
+co = cplx.ComplexAggregator()
+print(f"Complexes: {len(co.complexes)}")
+
+# Enzyme-substrate aggregator (kinase, phosphatase, methyltransferase, ...)
+es = enz_sub.EnzymeSubstrateAggregator()
+print(f"Enzyme-substrate relationships: {len(es)}")
+
+# Intercell categories merged across resources
+ic = intercell.IntercellAnnotation()
+print(f"Intercell records: {len(ic)}")
+```
+
+### Module 5: ID Mapping — `pypath.utils.mapping`
+
+Translate identifiers across databases and resolve organism/gene-symbol/UniProt mappings used internally by every input module.
+
+```python
+from pypath.utils import mapping
+
+# Single-record translation (returns a set of equivalents)
+print(mapping.map_name("EGFR", "genesymbol", "uniprot"))         # → {'P00533'}
+print(mapping.map_name("P00533", "uniprot", "ensembl_gene_id"))  # → ENSG00000146648
+print(mapping.map_name("C01152", "kegg", "inchi"))               # KEGG → InChI
+
+# Bulk translation
+genes = ["EGFR", "KRAS", "BRAF", "TP53"]
+uniprot_map = {g: mapping.map_name(g, "genesymbol", "uniprot") for g in genes}
+print(uniprot_map)
+
+# Inspect available ID types
+mapper = mapping.get_mapper()
+print("Identifier types known:", len(mapper.id_types()))
+```
+
+### Module 6: Cache and Settings — `pypath.share.curl` / `pypath.share.settings`
+
+Manage the on-disk download cache, force fresh downloads, and tune timeouts or debug verbosity.
+
+```python
+from pypath.share import curl, settings
+
+# Default cache dirs (expand to absolute paths)
+print("Cache dir:    ", settings.get("cachedir"))
+print("Pickles dir:  ", settings.get("pickle_dir"))
+print("Secrets dir:  ", settings.get("secrets_dir"))
+
+# Bypass cache for a single call (useful when a resource updates)
+from pypath.inputs import depod
+with curl.cache_off():
+    fresh = depod.depod_enzyme_substrate()
+
+# Delete a cached file before the next call (after a corrupted download)
+with curl.cache_delete_on():
+    fixed = depod.depod_enzyme_substrate()
+
+# Bump the timeout for a slow resource
+with settings.context(curl_timeout=360):
+    big = depod.depod_enzyme_substrate()
+
+# Verbose curl logging for troubleshooting
+with curl.debug_on():
+    debug = depod.depod_enzyme_substrate()
+```
+
+### Module 7: High-Level OmniPath Database Manager — `pypath.omnipath`
+
+The `omnipath` namespace exposes the same datasets as the public web service, but rebuilt locally with full provenance.
+
+```python
+from pypath import omnipath
+
+# Lazy-built database manager: first call builds, subsequent calls use the pickle
+cu = omnipath.db.get_db("curated")     # literature-curated signaling
+op = omnipath.db.get_db("omnipath")    # full integrated network
+tft = omnipath.db.get_db("tf_target")  # transcriptional regulation
+print(cu)   # <Network ... nodes / ... edges>
+print(op)
+print(tft)
+
+# List built-in database names
+print("Available DBs:", list(omnipath.db.datasets()))
+
+# Force a rebuild for a specific dataset
+omnipath.db.remove_db("curated")
+cu = omnipath.db.get_db("curated")
+```
+
+## Common Workflows
+
+### Workflow 1: Rebuild a Snapshot of OmniPath Locally
+
+```python
+from pypath.core import network
+from pypath.resources import network as netres
+from pathlib import Path
+
+snap = Path("omnipath_snapshot/")
+snap.mkdir(exist_ok=True)
+
+n = network.Network()
+n.load(netres.pathway)
+n.load(netres.pathway_extra)
+n.load(netres.kinase_extra)
+n.load(netres.ligand_receptor)
+n.load(netres.transcription_dorothea, only_directions=True)
+n.load(netres.enzyme_substrate)
+
+print(f"Built snapshot: {n.vcount} nodes / {n.ecount} edges")
+n.save_to_pickle(snap / "network.pkl")
+n.records().to_parquet(snap / "edges.parquet")
+print("Snapshot pickled and exported.")
+```
+
+### Workflow 2: Add a Custom In-house Resource to OmniPath
+
+```python
+from pypath.core import network
+from pypath.resources import network as netres
+from pypath.inputs import common
+import csv
+
+def my_curated_edges():
+    """Yield edges from an internal curation TSV."""
+    rows = []
+    with open("inhouse_signaling.tsv") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for r in reader:
+            rows.append((
+                r["source_uniprot"], r["target_uniprot"],
+                r["effect"],          # 'stimulation' / 'inhibition'
+                r["pmids"],           # 'pmid1;pmid2'
+            ))
+    return rows
+
+# Build the standard OmniPath core, then layer the custom edges on top
+n = network.Network()
+n.load(netres.pathway)
+
+custom_added = 0
+for src, tgt, effect, pmids in my_curated_edges():
+    n.add_interaction(
+        a=src, b=tgt,
+        attrs={
+            "directed":    True,
+            "effect":      effect,
+            "references":  pmids.split(";"),
+            "resource":    "InHouseCuration",
+        },
+    )
+    custom_added += 1
+
+print(f"Custom edges added: {custom_added}")
+print(f"Network total: {n.vcount} nodes / {n.ecount} edges")
+n.save_to_pickle("network_plus_custom.pkl")
+```
+
+### Workflow 3: Build a Tissue-Specific Ligand-Receptor Network
+
+```python
+from pypath.core import intercell
+from pypath import omnipath
+
+# Build (or load) the integrated databases
+ic = omnipath.db.get_db("intercell")
+op = omnipath.db.get_db("omnipath")
+
+# Filter to ligand and receptor entities
+ligands   = ic.select(scope="generic", category="ligand").entities()
+receptors = ic.select(scope="generic", category="receptor").entities()
+print(f"Ligands: {len(ligands)}   Receptors: {len(receptors)}")
+
+# Project onto OmniPath edges and keep ligand → receptor pairs
+lr_edges = []
+for ia in op.interactions.values():
+    if ia.a.identifier in ligands and ia.b.identifier in receptors:
+        lr_edges.append((ia.a.label, ia.b.label, len(ia.evidences)))
+
+print(f"Ligand → Receptor edges: {len(lr_edges)}")
+print(sorted(lr_edges, key=lambda x: -x[2])[:5])
+```
+
+### Workflow 4: ID Translation for a Multi-omics Gene Table
+
+```python
+from pypath.utils import mapping
+import pandas as pd
+
+table = pd.read_csv("multiomics_genes.csv")  # columns: gene_symbol, ensembl_id, ...
+def to_uniprot(s):
+    hits = mapping.map_name(s, "genesymbol", "uniprot")
+    return next(iter(hits)) if hits else None
+
+table["uniprot"] = table["gene_symbol"].apply(to_uniprot)
+unmapped = table[table["uniprot"].isna()]
+print(f"Mapped: {len(table) - len(unmapped)}/{len(table)}  unmapped: {len(unmapped)}")
+table.to_csv("multiomics_genes_with_uniprot.csv", index=False)
+```
+
+## Key Parameters
+
+| Parameter | Module / Function | Default | Range / Options | Effect |
+|-----------|------------------|---------|-----------------|--------|
+| `only_directions` | `Network.load` | `False` | `True` / `False` | When loading a regulatory resource, keep direction but discard sign and effect details |
+| `cache_off` (context) | `pypath.share.curl` | off | context manager | Bypass on-disk cache and force fresh HTTP download |
+| `cache_delete_on` (context) | `pypath.share.curl` | off | context manager | Delete cached entries before download (recover from corrupted files) |
+| `curl_timeout` | `settings.context` | `120` (s) | `30`–`3600` | HTTP timeout when fetching upstream resources |
+| `cachedir` | `pypath.share.settings` | `~/.pypath/cache` | any path | Override the on-disk cache root |
+| `pickle_dir` | `pypath.share.settings` | `~/.pypath/pickles` | any path | Override the integrated-database pickle directory |
+| `head` | `inputs.<resource>.<table>` | `None` | int | Return only the first N rows (useful for quick sanity checks) |
+| `target_id_type` | `mapping.map_name` | — | `uniprot`, `genesymbol`, `ensembl_gene_id`, `entrez`, `hgnc`, `mgi`, `refseqp`, `kegg`, `chebi`, `hmdb`, `inchi` | Destination identifier type |
+| `ncbi_tax_id` | many input loaders | `9606` (human) | NCBI tax IDs (e.g., `10090` mouse) | Limits resource pulls to the requested organism |
+| `dataset` | `omnipath.db.get_db` | — | `curated`, `omnipath`, `tf_target`, `mirna_mrna`, `complex`, `annotations`, `intercell`, `enz_sub` | Selects which integrated database to materialize |
+
+## Common Recipes
+
+### Recipe: Inspect Per-Resource Evidence on a Specific Edge
+
+When to use: you want to know which databases support a particular interaction and with what literature.
+
+```python
+from pypath import omnipath
+
+op = omnipath.db.get_db("omnipath")
+
+# Find every edge between EGFR and GRB2
+hits = [ia for ia in op.interactions.values()
+        if {ia.a.label, ia.b.label} == {"EGFR", "GRB2"}]
+print(f"Edges EGFR-GRB2: {len(hits)}")
+
+for ia in hits:
+    print(f"{ia.a.label} -> {ia.b.label}")
+    for ev in ia.evidences:
+        print(f"  resource={ev.resource}  references={list(ev.references)[:3]}")
+```
+
+### Recipe: List Every Built-in Resource
+
+When to use: discover which databases pypath can load before designing a custom build.
+
+```python
+from pypath.resources import network as netres
+
+for preset in ("pathway", "pathway_extra", "kinase_extra",
+               "ligand_receptor", "transcription_dorothea",
+               "transcription_collectri", "mirna_target",
+               "enzyme_substrate"):
+    resources = sorted(getattr(netres, preset))
+    print(f"\n{preset} ({len(resources)} resources):")
+    for r in resources:
+        print(f"  - {r}")
+```
+
+### Recipe: Reuse a Pickled Database Across Sessions
+
+When to use: avoid the 30–90 minute first-time build on every analysis run.
+
+```python
+from pathlib import Path
+from pypath.core import network
+from pypath.resources import network as netres
+
+pkl = Path("omnipath.pkl")
+
+if pkl.exists():
+    n = network.Network.from_pickle(pkl)
+    print(f"Loaded from pickle: {n.vcount} nodes / {n.ecount} edges")
+else:
+    n = network.Network()
+    n.load(netres.pathway)
+    n.load(netres.enzyme_substrate)
+    n.save_to_pickle(pkl)
+    print(f"Built and pickled: {n.vcount} nodes / {n.ecount} edges")
+```
+
+### Recipe: Convert a Network to igraph for Topological Analysis
+
+When to use: compute centralities, communities, or shortest paths on the integrated network.
+
+```python
+from pypath import omnipath
+
+op = omnipath.db.get_db("omnipath")
+g = op.igraph_network()  # builds an igraph.Graph with vertex/edge attrs
+
+print(f"igraph: {g.vcount()} nodes / {g.ecount()} edges")
+betw = g.betweenness()
+top = sorted(zip(g.vs["label"], betw), key=lambda x: -x[1])[:10]
+print("Top betweenness:", top)
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `ModuleNotFoundError: pypath` | Wrong package name | Install with `pip install pypath-omnipath` (the importable name is `pypath`) |
+| First load takes > 1 hour | Full build downloading 100+ resources | Use `omnipath.db.get_db("curated")` for a smaller subset; pickle the result for reuse |
+| `pycurl` install fails | Missing libcurl headers / OpenSSL on macOS | `brew install curl openssl` then `PYCURL_SSL_LIBRARY=openssl pip install --no-cache-dir pycurl` |
+| `Resource X failed to download` warnings | Upstream resource temporarily down | Re-run with `curl.cache_delete_on()` later; pypath will skip dead resources by default |
+| Cache disk usage exceeds tens of GB | Many large resources cached locally | Move cache: `settings.set("cachedir", "/data/pypath_cache")` and re-run |
+| Stale pickle after pypath upgrade | Pickle was written by an older version | Delete `~/.pypath/pickles/` and rebuild; pickles are not always forward-compatible |
+| `KeyError` from `mapping.map_name` | Identifier type name typo | List supported types with `mapping.get_mapper().id_types()` |
+| Network has zero edges after `load()` | Wrong organism or empty resource subset | Pass `ncbi_tax_id=9606` (or your species), confirm the resource supports that organism |
+| Memory error during build | Several integrated DBs exceed 8 GB residency | Run on a machine with ≥ 32 GB RAM, or build databases one at a time and pickle each |
+
+## Related Skills
+
+- [`omnipath-knowledge-graph`](../omnipath-knowledge-graph/SKILL.md) — lightweight REST client for the public OmniPath service when no custom build is needed
+- [`string-database-ppi`](../string-database-ppi/SKILL.md) — STRING-only protein-protein interactions
+- [`reactome-database`](../reactome-database/SKILL.md) — Reactome pathway hierarchy and enrichment
+- [`kegg-pathway-analysis`](../kegg-pathway-analysis/SKILL.md) — KEGG-only pathway analysis
+
+## References
+
+- [pypath GitHub: saezlab/pypath](https://github.com/saezlab/pypath) — source code, issue tracker, and changelog
+- [pypath documentation](https://pypath.omnipathdb.org/) — API reference, manual, and resource catalog
+- [OmniPath web service: omnipathdb.org](https://omnipathdb.org/) — REST endpoints and dataset catalog
+- [Türei et al. (2021) Mol Syst Biol 17(3):e9923](https://doi.org/10.15252/msb.20209923) — primary OmniPath / pypath publication
+- [Türei et al. (2016) Nat Methods 13:966–967](https://doi.org/10.1038/nmeth.4077) — original OmniPath signaling resource
+- [Resource catalog (saezlab)](https://saezlab.github.io/pypath/) — visual index of all input modules and their citations


### PR DESCRIPTION
## Summary

Adds two skills under `systems-biology-multiomics/` covering the OmniPath ecosystem from the Saez Lab — the largest open meta-database for signaling, transcriptional, post-translational, complex, intercellular communication, and protein annotation data, integrating 150+ primary resources:

- **`omnipath-knowledge-graph`** (database): Python REST client for the OmniPath web service. Six core query modules (interactions, enzyme-substrate, complexes, annotations, intercell, options/cache). Returns tidy pandas DataFrames; supports license filtering (academic / commercial), organism selection, and DoRothEA confidence cutoffs.
- **`pypath-network-builder`** (toolkit): the framework that *builds* OmniPath. Seven core modules — `Network` class, resource presets, ~150 input modules, the `AnnotationTable` / `ComplexAggregator` / `EnzymeSubstrateAggregator` / `IntercellAnnotation` aggregators, ID mapping, cache+settings, and the high-level `omnipath.db` database manager. Use when extending OmniPath, adding custom resources, or rebuilding a reproducible local snapshot.

Both skills cross-reference each other and existing `string-database-ppi`, `reactome-database`, `kegg-pathway-analysis`, and `cellchat-cell-communication` entries for routing.

Registry: 199 → 201 entries.

## Checklist

- [x] `pixi run test` passes locally (4177 passed, 0 failed)
- [x] `registry.yaml` updated with the new entry
- [x] Skill type is correctly set: pipeline / toolkit / database / guide
- [x] `description` field is ≤ 1024 characters
- [x] Frontmatter has `name`, `description`, `license`
- [x] Required sections present in correct order (see `CLAUDE.md`)
- [x] Code blocks are runnable with sample data or clear placeholders
- [x] Troubleshooting table has 5+ rows
- [x] Key Parameters table has 5+ rows

## Skill(s) added or modified

- `skills/systems-biology-multiomics/omnipath-knowledge-graph/SKILL.md` (new)
- `skills/systems-biology-multiomics/pypath-network-builder/SKILL.md` (new)
- `registry.yaml` (modified — appended two entries)
- `README.md` (modified — total 199 → 201; Systems Biology & Multi-omics 11 → 13; toolkits 72 → 73; database connectors 53 → 54)