### PR TITLE
chore: add optional registry tags schema

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1,6 +1,23 @@
 # Skills Registry
 # Each entry is added here when a new SKILL.md is created.
 # This file is maintained by following the workflow in CLAUDE.md (Step 5).
+#
+# Entry schema:
+#   name         (required) — kebab-case unique slug; must match frontmatter `name`
+#   type         (required) — always "skill" today
+#   sub_type     (required) — pipeline | toolkit | database | guide
+#   category     (required) — primary category directory under skills/
+#   path         (required) — relative path to SKILL.md
+#   description  (required) — short discovery string; first 120 chars carry the
+#                             discovery weight (keep tool/domain keywords up front)
+#   date_added   (required) — ISO-8601 date the entry first landed
+#   tags         (optional) — list of cross-cutting tags for secondary discovery.
+#                             Use when an entry meaningfully belongs to more than
+#                             one category. Examples: ["databases", "literature"],
+#                             ["machine-learning"], ["medical-informatics"].
+#                             Tags do NOT replace `category`; the primary home
+#                             stays in `category`. Tag names are lowercase and
+#                             hyphen-separated, validated as plain strings only.
 
 entries:
   - name: "scanpy-scrna-seq"

--- a/scripts/validate_registry.py
+++ b/scripts/validate_registry.py
@@ -2,6 +2,7 @@
 """Validate registry.yaml: check all entries point to existing SKILL.md files
 with valid YAML frontmatter."""
 
+import re
 import sys
 from pathlib import Path
 
@@ -11,6 +12,7 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 REGISTRY_PATH = ROOT / "registry.yaml"
 REQUIRED_FRONTMATTER = {"name", "description"}
+TAG_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 
 def parse_frontmatter(skill_path: Path) -> dict:
@@ -50,6 +52,23 @@ def validate() -> list[str]:
         for field in ("name", "path", "category", "description"):
             if not entry.get(field):
                 errors.append(f"[{name}] Missing registry field: {field}")
+
+        # Optional tags field
+        tags = entry.get("tags")
+        if tags is not None:
+            if not isinstance(tags, list):
+                errors.append(f"[{name}] tags must be a list, got {type(tags).__name__}")
+            else:
+                for t in tags:
+                    if not isinstance(t, str):
+                        errors.append(f"[{name}] tag must be a string, got {type(t).__name__}: {t!r}")
+                    elif not TAG_PATTERN.match(t):
+                        errors.append(
+                            f"[{name}] tag '{t}' must be lowercase kebab-case "
+                            f"(matching {TAG_PATTERN.pattern})"
+                        )
+                if len(tags) != len(set(tags)):
+                    errors.append(f"[{name}] tags has duplicates: {tags}")
 
         # File existence
         skill_path = ROOT / entry.get("path", "")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -85,3 +85,47 @@ class TestSkillDiscovery:
 
         unregistered = on_disk - registered_paths
         assert unregistered == set(), f"SKILL.md files not in registry: {unregistered}"
+
+
+class TestTagsField:
+    """Validate the optional `tags` field schema (PR1).
+
+    tags is optional. When present, it must be a list of unique
+    lowercase kebab-case strings used for cross-cutting discovery
+    alongside the primary `category`.
+    """
+
+    def test_tags_is_list_when_present(self, entries):
+        bad = []
+        for e in entries:
+            tags = e.get("tags")
+            if tags is not None and not isinstance(tags, list):
+                bad.append((e["name"], type(tags).__name__))
+        assert bad == [], f"tags must be a list when present: {bad}"
+
+    def test_tags_items_are_strings(self, entries):
+        bad = []
+        for e in entries:
+            for t in e.get("tags") or []:
+                if not isinstance(t, str):
+                    bad.append((e["name"], t, type(t).__name__))
+        assert bad == [], f"tag items must be strings: {bad}"
+
+    def test_tags_are_kebab_case(self, entries):
+        import re
+
+        pattern = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+        bad = []
+        for e in entries:
+            for t in e.get("tags") or []:
+                if isinstance(t, str) and not pattern.match(t):
+                    bad.append((e["name"], t))
+        assert bad == [], f"tags must be lowercase kebab-case: {bad}"
+
+    def test_tags_no_duplicates_within_entry(self, entries):
+        bad = []
+        for e in entries:
+            tags = e.get("tags") or []
+            if len(tags) != len(set(tags)):
+                bad.append((e["name"], tags))
+        assert bad == [], f"tags have duplicates within entry: {bad}"


### PR DESCRIPTION
## Summary
Introduce an optional `tags: []` field on registry entries for cross-cutting secondary discovery. Useful when an entry meaningfully belongs to more than one category — e.g., literature databases that live in `scientific-writing` but should also surface under a `databases` lens, or ML libraries that span `scientific-computing` and a future `medical-informatics`.

### Schema rules (enforced by validator + tests)
- `tags` is **optional** — absence is normal
- When present, must be a list of unique strings
- Each tag matches `^[a-z0-9][a-z0-9-]*$` (lowercase kebab-case)
- `tags` does **not** replace `category` — primary home stays in `category`

### Changes
- `registry.yaml` header comment documents the full schema, including `tags`
- `scripts/validate_registry.py`: validate type, item type, pattern, uniqueness
- `tests/test_registry.py`: new `TestTagsField` (4 tests)

## Test plan
- [x] `pixi run test` passes (4135 → 4139)
- [x] reviewer confirms schema rules (kebab-case, list of strings, optional)
- [x] reviewer confirms naming convention (`tags` vs `secondary_categories` vs `topics`)