### PR TITLE
refactor: templates audit — embed description rules, scripts/, tags note

### DIFF
--- a/templates/SKILL_TEMPLATE.md
+++ b/templates/SKILL_TEMPLATE.md
@@ -1,8 +1,21 @@
 <!-- Template: Pipeline Sub-type — for tools with a linear input→processing→output flow.
-     For toolkit-style tools (multiple independent modules), use SKILL_TEMPLATE_TOOLKIT.md instead. -->
+     For toolkit-style tools (multiple independent modules), use SKILL_TEMPLATE_TOOLKIT.md instead.
+
+     Scaffolding shortcut: `.claude/skills/sciagent-skill-creator/` can drop this template
+     into the correct category, fill the frontmatter, and append the registry entry for you.
+
+     Note: the optional `tags: [...]` field lives in registry.yaml (entry-level), NOT in the
+     SKILL.md frontmatter below. See CLAUDE.md Step 5 "tags field" for when to use it. -->
 ---
 name: "Skill Name Here"
-description: "Brief description of what this skill does and when to use it (max 1024 chars)"
+# Description rules (CLAUDE.md Step 5):
+#   - Length ≤ 1024 chars; first 120 chars carry discovery weight
+#   - Lead with tool name or domain keyword — NOT stop verbs (Use/A/An/The/Query/Fetch/Run)
+#   - Cross-references ("For X use Y") go at the END
+#   - No promotional adjectives (powerful/comprehensive/state-of-the-art/...)
+# Good: "PyDESeq2 differential expression for bulk RNA-seq. Wraps DESeq2's negative-binomial model in Python; pandas in, results DataFrame out. ..."
+# Bad:  "Use this comprehensive skill to perform powerful differential expression analysis..."
+description: "<Tool/Domain keyword> <what it does>. <Inputs → outputs>. <Disambiguation: for X use Y>."
 license: "CC-BY-4.0"  # Use tool's license if known; CC-BY-4.0 for original content
 ---
 
@@ -135,6 +148,17 @@ result = package1.other_method(data, correction=True)
 | `ModuleNotFoundError` | Package not installed | `pip install package1` |
 | `MemoryError` | Dataset too large | Use chunked processing or subsample |
 | Empty results | Input format mismatch | Check input file has expected columns |
+
+## Bundled Resources
+
+<!-- Optional. Only include if this skill ships sibling directories next to SKILL.md.
+     See CLAUDE.md Step 4 "Bundled resources" for the references/ vs assets/ vs scripts/ rule.
+     Extract code into scripts/ when a block exceeds ~80 lines, the same helper repeats
+     across recipes, or the entry effectively ships a CLI utility. -->
+
+- `references/<topic>.md` — long-form prose or decision tables the agent loads on demand
+- `assets/<file.ext>` — copy-paste templates, fixtures, or static artifacts
+- `scripts/<name>.py` — runnable helpers; include docstring header (purpose + usage)
 
 ## References
 

--- a/templates/SKILL_TEMPLATE_PROSE.md
+++ b/templates/SKILL_TEMPLATE_PROSE.md
@@ -1,6 +1,22 @@
+<!-- Template: Guide Sub-type (prose-centric) — for entries whose core value is domain
+     knowledge, decision frameworks, and best practices rather than runnable code.
+     For code-centric entries, use SKILL_TEMPLATE.md (Pipeline) or SKILL_TEMPLATE_TOOLKIT.md.
+
+     Scaffolding shortcut: `.claude/skills/sciagent-skill-creator/` can drop this template
+     into the correct category, fill the frontmatter, and append the registry entry for you.
+
+     Note: the optional `tags: [...]` field lives in registry.yaml (entry-level), NOT in the
+     SKILL.md frontmatter below. See CLAUDE.md Step 5 "tags field" for when to use it. -->
 ---
 name: "Skill Name Here"
-description: "Brief description of what domain knowledge this covers and when to consult it (max 1024 chars)"
+# Description rules (CLAUDE.md Step 5):
+#   - Length ≤ 1024 chars; first 120 chars carry discovery weight
+#   - Lead with the domain or decision-space keyword — NOT stop verbs (Use/A/An/The/...)
+#   - Cross-references ("For X use Y") go at the END
+#   - No promotional adjectives (powerful/comprehensive/state-of-the-art/...)
+# Good: "scRNA-seq cell-type annotation decision framework. Three-tier strategy: manual markers, CellTypist, popV ensemble transfer. ..."
+# Bad:  "A comprehensive guide to single-cell annotation best practices..."
+description: "<Domain or decision-space keyword> <what it covers>. <When to consult>. <Disambiguation>."
 license: "CC-BY-4.0"
 ---
 

--- a/templates/SKILL_TEMPLATE_TOOLKIT.md
+++ b/templates/SKILL_TEMPLATE_TOOLKIT.md
@@ -1,9 +1,22 @@
 <!-- Template: Toolkit Sub-type — for tools that are collections of independent functional modules.
      For pipeline-style tools (linear input→processing→output), use SKILL_TEMPLATE.md instead.
-     For database/API wrapper tools, use this template with adaptations noted in CLAUDE.md. -->
+     For database/API wrapper tools, use this template with adaptations noted in CLAUDE.md.
+
+     Scaffolding shortcut: `.claude/skills/sciagent-skill-creator/` can drop this template
+     into the correct category, fill the frontmatter, and append the registry entry for you.
+
+     Note: the optional `tags: [...]` field lives in registry.yaml (entry-level), NOT in the
+     SKILL.md frontmatter below. See CLAUDE.md Step 5 "tags field" for when to use it. -->
 ---
 name: "Toolkit Name Here"
-description: "Brief description of what this toolkit does and when to use it (max 1024 chars)"
+# Description rules (CLAUDE.md Step 5):
+#   - Length ≤ 1024 chars; first 120 chars carry discovery weight
+#   - Lead with tool name or domain keyword — NOT stop verbs (Use/A/An/The/Query/Fetch/Run)
+#   - Cross-references ("For X use Y") go at the END
+#   - No promotional adjectives (powerful/comprehensive/state-of-the-art/...)
+# Good: "RDKit cheminformatics toolkit. Mol objects from SMILES/SDF/PDB, descriptors, fingerprints, substructure search, 3D conformers. For ML featurization use molfeat; ..."
+# Bad:  "A powerful and comprehensive cheminformatics library for working with molecules..."
+description: "<Tool/Domain keyword> <what it does>. <Module coverage>. <Disambiguation: for X use Y>."
 license: "CC-BY-4.0"
 ---
 
@@ -261,6 +274,17 @@ print("Converted format_a → format_b")
 
 - **related-tool-1** — how this tool connects (e.g., "downstream analysis after data preparation")
 - **related-tool-2** — how this tool connects (e.g., "alternative for X use-case")
+
+## Bundled Resources
+
+<!-- Optional. Only include if this skill ships sibling directories next to SKILL.md.
+     See CLAUDE.md Step 4 "Bundled resources" for the references/ vs assets/ vs scripts/ rule.
+     Extract code into scripts/ when a block exceeds ~80 lines, the same helper repeats
+     across recipes, or the entry effectively ships a CLI utility. -->
+
+- `references/<topic>.md` — long-form prose or decision tables the agent loads on demand
+- `assets/<file.ext>` — copy-paste templates, fixtures, or static artifacts
+- `scripts/<name>.py` — runnable helpers; include docstring header (purpose + usage)
 
 ## References
 


### PR DESCRIPTION
## Summary
Bring the three SKILL.md templates in line with the workflow rules codified in CLAUDE.md so authors don't bounce between files to recall them.

### Per-template changes
1. **Top-of-file comment**: now clarifies that the optional `tags: [...]` field lives in `registry.yaml` (entry-level), NOT in SKILL.md frontmatter. Heads off the easy mistake of adding `tags:` to frontmatter.
2. **Frontmatter `description` placeholder**: rewritten from prose ("Brief description ...") to a structural placeholder (`<Tool/Domain keyword> <what it does>. ...`). Inline YAML comments codify the four description rules (1024 ceiling, first-120-char keyword lead, stop-verb prohibition, no promotional adjectives) with a sub-type-appropriate Good/Bad example.
3. **Pipeline and Toolkit templates**: added an optional `## Bundled Resources` section before `## References`, mirroring the `references/` vs `assets/` vs `scripts/` split documented in CLAUDE.md Step 4. Prose template already had `## Companion Assets` — left untouched.

### Counts
- Pipeline +26 lines, Toolkit +26 lines, Prose +17 lines

### Forward references / dependencies
- Description rules documented in **#28** — this PR makes them visible at the point of authoring
- `scripts/` convention documented in **#28** — this PR adds the section stub
- `tags` schema lives in **#27** — this PR makes the registry-only locus explicit

### Behavior note
Templates are not validated by the test suite (not under `skills/`). The scaffolder reads them and substitutes frontmatter line-by-line, so the new comments pass through into generated entries as authoring hints — authors should strip them during content fill-in. Follow-up: PR10 could grow a comment-stripper to clean output automatically.

## Test plan
- [x] `pixi run test` passes (4135 tests)
- [x] reviewer opens each template and confirms the description rules read clearly to a first-time author
- [x] reviewer confirms scaffolder pointer + tags-in-registry-only note are at the right altitude (top comment)