### PR TITLE
docs: add compute/viz separation rule to DESeq2 skill

### DIFF
--- a/skills/genomics-bioinformatics/rnaseq/deseq2-differential-expression/SKILL.md
+++ b/skills/genomics-bioinformatics/rnaseq/deseq2-differential-expression/SKILL.md
@@ -243,6 +243,8 @@ write.csv(sig_genes, "deseq2_significant.csv")
 
 ### Step 7: Visualize — MA Plot, Volcano Plot, and Heatmap
 
+> **Compute/viz separation (required):** Do not combine DESeq2 computation and plotting in the same code block. Step 6 (or Step 5) saves the results CSV; this step loads that CSV and produces plots only. This way plots can be regenerated or restyled without re-running the expensive computation.
+
 ```r
 library(EnhancedVolcano)
 library(pheatmap)


### PR DESCRIPTION
# 무엇을 위한 PR인가요?

run 로그 분석에서 확인된 두 가지 문제를 프롬프트 규칙으로 예방
1. plot 수정요청 시 DESeq2가 불필요하게 재실행되는 현상 (re-running)
2. ENSEMBL gene and gene_symbol conversion이 원활하게 이루어지지 않는 현상 (output csv 활용하지 않는 현상) 

## 무엇이 바뀌었나요?
Skill(s) added or modified
수정 파일: skills/genomics-bioinformatics/deseq2-differential-expression/SKILL.md

위치: 243번째 줄, ### Step 7: Visualize 헤더 바로 아래 (Step 7 헤더와 ```r 코드블록 사이에)

추가내용:

> **Compute/viz separation (required):** Do not combine DESeq2 computation and plotting in the same code block. Step 6 (or Step 5) saves the results CSV; this step loads that CSV and produces plots only. This way plots can be regenerated or restyled without re-running the expensive computation.


## 리뷰를 위해 알아야 할 내용이 있나요?
<!--
SKILL 만 수정되어도 ENSEMBL 유전자와 gene-symbol 모두 csv 에 포함되고 gene symbol로 plot 수정 가능해지면서 시간이 단축되는 효과를 만들어냄. 
-->

## 체크리스트 (해당되는 내용에 체크해주세요.)

- [x] 테스트를 통과했습니다.
- [ ] 새로운 기능 또는 수정된 기능을 위한 테스트를 추가했습니다.
- [ ] 이 수정으로 인해 사이드 이펙트가 발생 할 수 있습니다.
- [ ] 이 PR은 인프라 변경을 동반합니다.
- [ ] 이 PR은 API 변경을 동반합니다.


## TODO 트래킹

<!--

-->
