### PR TITLE
feat: add rdkit-chemdraw-cdxml skill

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -62,6 +62,13 @@ entries:
     path: "skills/structural-biology-drug-discovery/rdkit-cheminformatics/SKILL.md"
     description: "Cheminformatics toolkit for molecular analysis: SMILES/SDF parsing, descriptors, fingerprints, similarity search, substructure filtering, drug-likeness, 3D conformers"
     date_added: "2026-02-16"
+  - name: "rdkit-chemdraw-cdxml"
+    type: skill
+    sub_type: toolkit
+    category: "structural-biology-drug-discovery"
+    path: "skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md"
+    description: "Read, write, and edit ChemDraw CDX/CDXML files with rdkit.Chem.rdChemDraw plus direct XML editing. Parse molecules and reactions, write structures with good 2D depiction, and hand-build arrows, plus signs, reaction schemes, and text/labels that RDKit cannot write. Cross-domain (figure generation)."
+    date_added: "2026-08-01"
   - name: "gget-genomic-databases"
     type: skill
     sub_type: database

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -332,10 +332,15 @@ tree.write("output_reaction.cdxml", encoding="unicode", xml_declaration=True)
 
 `scripts/build_reaction_scheme.py` turns `(smiles, name, conditions)` steps into a laid-out scheme **and its PNG in one call**, handling grid layout, globally unique ids, single arrows, and conditions text placed clear of structures — the defects that recur when schemes are hand-built. Cells auto-size to the largest structure, so big molecules never overlap. Model convergent/multi-component steps by folding co-reactants into `conditions` (e.g. `["+ (MeO2C)2C=CHOMe", "Base, MeCN"]`), keeping one main-chain structure per cell.
 
-The `scripts/` files are **not on the execution environment's import path** — copy the two you need into your working directory first (read each with `read_file` from the skill's `scripts/` dir and write it beside your code), then import:
+The `scripts/` files can be **read** from the skill path but **not imported** from there — they are not on the execution sandbox's import path. Copy the two you need into your working directory first, then import. Each script depends only on rdkit (+ epam.indigo), never on the other, so copy them independently:
 
 ```python
-# after copying build_reaction_scheme.py and check_scheme.py into the workdir:
+# 1) Copy the helpers into the workdir (read_file is routed to the skill backend):
+_SKILL = "SciAgent-Skills/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts"
+for name in ("build_reaction_scheme.py", "check_scheme.py"):
+    open(name, "w").write(read_file(f"{_SKILL}/{name}"))   # read_file = your file tool
+
+# 2) Now they import normally from the workdir:
 from build_reaction_scheme import build_scheme
 from check_scheme import check_all
 
@@ -416,7 +421,7 @@ print(minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
 
 ## Bundled Resources
 
-The `scripts/` files are read-only in the skill directory and are **not importable from there** — copy the ones you need into your working directory (read with `read_file`, write locally), then `import` or run them.
+The `scripts/` files can be read from the skill path but **not imported from there** — copy the one you need into your working directory (`read_file` it, write locally), then `import` or run it (see Workflow 4 for the exact copy snippet). Each is self-contained and depends only on rdkit (+ epam.indigo).
 
 - `references/cdxml-schema-reference.md` — element/attribute cheat-sheet (`n`, `b`, `arrow`, `graphic`, `step`/`scheme`, `t`/`s`, `fonttable`, `colortable`), coordinate conventions, enum tables, and a copy-paste document header.
 - `scripts/build_reaction_scheme.py` — assemble a multi-step scheme from `(smiles, name, conditions)` steps and render the PNG in one call; auto-sizes cells so structures never overlap. Library (`build_scheme(...)`) or CLI (`python build_reaction_scheme.py steps.json out.cdxml out.png "Title"`).

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -18,13 +18,14 @@ ChemDraw's native formats are CDX (binary) and CDXML (an XML serialization of th
 - Add captions, atom labels, or annotations to a chemical drawing at specific canvas positions
 - Modify an existing ChemDraw file (relabel a group, add a note, reposition an arrow) without losing its arrows/text
 - Improve the 2D layout of a structure before export (CoordGen, template alignment, straightening)
+- Render a `.cdxml`/`.cdx` to PNG or SVG for a visual quality check of the drawing you generated
 - Batch-generate ChemDraw figures for a reaction dataset or SAR table
 - Use `rdkit-cheminformatics` instead when you only need descriptors, fingerprints, similarity, or SMARTS — no ChemDraw I/O
 - For multi-format 3D structure conversion (MOL2, XYZ, PDB), use `openbabel` instead; this toolkit is 2D ChemDraw-specific
 
 ## Prerequisites
 
-- **Python packages**: `rdkit` (2023.03+ recommended; must be built with ChemDraw support), `lxml` (optional, for pretty-printing/XPath); `xml.etree.ElementTree` from the stdlib is sufficient for editing
+- **Python packages**: `rdkit` (2023.03+ recommended; must be built with ChemDraw support), `lxml` (optional, for pretty-printing/XPath); `xml.etree.ElementTree` from the stdlib is sufficient for editing. Optional: `epam.indigo` for rendering CDXML to PNG/SVG (Module 9)
 - **Data requirements**: SMILES/Mol objects for writing; `.cdxml` (UTF-8 text) or `.cdx` (binary) files for reading
 - **Environment**: Python 3.9+; verify ChemDraw write support at runtime (see below) — some conda builds omit it
 
@@ -287,6 +288,40 @@ tree.write("reaction_edited.cdxml", encoding="unicode", xml_declaration=True)
 print("Saved reaction_edited.cdxml")
 ```
 
+### Module 9: Rendering CDXML to PNG (visual QA)
+
+CDXML is not human-viewable on its own. **Always render what you generate and look
+at it** — rendering is the fastest way to catch overlapping structures, stray
+arrows (from duplicate/degenerate arrow ids), and text colliding with atoms.
+[Indigo](https://lifescience.opensource.epam.com/indigo/) (`epam.indigo`, renderer
+bundled) loads a CDXML — a scheme with arrows as a *reaction*, a lone structure as
+a *molecule* — and rasterizes arrows, text, and layout faithfully.
+
+```python
+from indigo import Indigo
+from indigo.renderer import IndigoRenderer
+
+def render_cdxml(cdxml_path, png_path, width=1600):
+    ind = Indigo()
+    rnd = IndigoRenderer(ind)
+    ind.setOption("render-output-format", "png")   # or "svg"
+    ind.setOption("render-background-color", "1,1,1")
+    ind.setOption("render-image-width", width)
+    cdxml = open(cdxml_path, encoding="utf-8").read()
+    try:
+        obj = ind.loadReaction(cdxml)   # scheme with arrows
+    except Exception:
+        obj = ind.loadMolecule(cdxml)   # single structure
+    rnd.renderToFile(obj, png_path)
+    return png_path
+
+print("Wrote", render_cdxml("scheme.cdxml", "scheme.png"))
+```
+
+RDKit can also draw a *parsed* reaction (`Draw.ReactionToImage(rxn)`), but it
+re-lays-out the molecules and drops the original ChemDraw arrows/text/positions —
+use Indigo when you want the file rendered as authored.
+
 ## Key Concepts
 
 ### CDXML coordinate system
@@ -456,6 +491,8 @@ print("Edited file saved; arrows and existing text preserved")
 
 11. **XML-escape special characters in text.** `<`, `>`, and `&` inside a `<s>` run must be written as `&lt;`, `&gt;`, `&amp;` (e.g. a retrosynthesis note "3 -> 4" becomes "3 -&gt; 4"). `ElementTree` escapes automatically when you set `.text`; only hand-written strings need manual escaping.
 
+12. **Render and look at every file you generate** (Module 9). CDXML is not viewable by eye; the only reliable check is to rasterize it. Rendering immediately exposes stray lines from a duplicate/degenerate arrow id, structures overlapping an arrow, condition text sitting on top of atoms, and a compressed scheme that dropped intermediates. Pair it with the validation recipe below (duplicate ids, repeated adjacent fragments, bond-length spread) so both the XML and the picture are checked before you hand the file over.
+
 ## Common Recipes
 
 ### Recipe: Validate a hand-built CDXML by re-reading it
@@ -499,6 +536,51 @@ pretty = minidom.parseString(open("esterification.cdxml", encoding="utf-8").read
 print(pretty.toprettyxml(indent="  ")[:1500])
 ```
 
+### Recipe: Lint a generated scheme before rendering
+
+When to use: catch the common auto-generation defects (duplicate ids, an
+accidentally repeated structure, uneven scale) that render as stray lines,
+floating duplicates, or mismatched sizes.
+
+```python
+import xml.etree.ElementTree as ET
+from collections import Counter
+import statistics
+
+def lint_cdxml(path):
+    root = ET.fromstring(open(path, encoding="utf-8").read())
+    problems = []
+    # 1) duplicate ids (two <arrow id="120">, or a node id reused by a <t>)
+    ids = [e.get("id") for e in root.iter() if e.get("id")]
+    dups = [i for i, c in Counter(ids).items() if c > 1]
+    if dups:
+        problems.append(f"duplicate ids: {dups}")
+    # 2) bond-length spread across fragments (should be near-uniform)
+    def med_bond(fr):
+        pos = {n.get("id"): tuple(map(float, n.get("p").split()))
+               for n in fr.iter("n") if n.get("p")}
+        ds = [((pos[b.get('B')][0]-pos[b.get('E')][0])**2 +
+               (pos[b.get('B')][1]-pos[b.get('E')][1])**2)**0.5
+              for b in fr.iter("b") if b.get("B") in pos and b.get("E") in pos]
+        return statistics.median(ds) if ds else 0
+    bl = [round(med_bond(fr), 1) for fr in root.iter("fragment")]
+    # Flag only gross scale mismatches; deliberate emphasis (e.g. a larger
+    # cage) is fine, so use a loose threshold rather than demanding uniformity.
+    if bl and (max(bl) - min(bl)) > 0.35 * max(bl):
+        problems.append(f"gross bond-length mismatch across fragments: {bl}")
+    # 3) an <arrow> shorter than half a bond (degenerate)
+    for a in root.iter("arrow"):
+        if a.get("Head3D") and a.get("Tail3D"):
+            hx, hy, _ = map(float, a.get("Head3D").split())
+            tx, ty, _ = map(float, a.get("Tail3D").split())
+            if ((hx-tx)**2 + (hy-ty)**2)**0.5 < 15:
+                problems.append(f"degenerate arrow id={a.get('id')} (too short)")
+    return problems
+
+issues = lint_cdxml("scheme.cdxml")
+print("CLEAN" if not issues else "ISSUES:\n  " + "\n  ".join(issues))
+```
+
 ## Troubleshooting
 
 | Problem | Cause | Solution |
@@ -515,6 +597,10 @@ print(pretty.toprettyxml(indent="  ")[:1500])
 | Molecules in a scheme are different sizes | Fragments assembled at different bond lengths | Rescale each fragment to one bond length (≈30) before assembling; `rdDepictor.NormalizeDepiction` per mol |
 | Structures present but no reaction shown | Scheme has no `<arrow>`/`<graphic>` line objects | Add an arrow per step; wire ids in `<step>` if RDKit must re-read it as a reaction |
 | Parser error on text with `<`, `>`, `&` | Unescaped special characters in a `<s>` run | Escape as `&lt;` `&gt;` `&amp;` (automatic when using `ElementTree` `.text`) |
+| Stray line crosses a structure in the render | Duplicate or degenerate `<arrow>` (e.g. two `<arrow id="120">`, one tiny) | Run the lint recipe; give every arrow a unique id and a real length (Head3D≠Tail3D) |
+| Condition text overlaps atoms/structures | Text placed on the structure instead of clear of the arrow | Put conditions above (arrow y − ~15) and below (arrow y + ~15); leave horizontal gaps between fragments |
+| Same structure appears twice / floating duplicate | A fragment was copied (e.g. a "from above" continuation) | Remove the duplicate fragment; lint recipe flags repeated adjacent SMILES |
+| `render*` options ignored / no image | Indigo renderer not installed, or CDXML loaded as molecule when it has arrows | `pip install epam.indigo`; try `loadReaction` first, fall back to `loadMolecule` |
 
 ## Bundled Resources
 
@@ -532,3 +618,4 @@ print(pretty.toprettyxml(indent="  ")[:1500])
 - [RDKit `rdMolDraw2D` / depiction docs](https://www.rdkit.org/docs/source/rdkit.Chem.Draw.rdMolDraw2D.html) — 2D coordinate generation and CoordGen
 - [CDX/CDXML format specification (CambridgeSoft SDK mirror)](https://chemapps.stolaf.edu/iupac/cdx/sdk/) — object and property reference for arrows, graphics, reactions, and text
 - [RDKit CDXML test fixtures](https://github.com/rdkit/rdkit/tree/master/Code/GraphMol/test_data/CDXML) — real ChemDraw-authored `.cdxml` examples
+- [Indigo toolkit (`epam.indigo`)](https://lifescience.opensource.epam.com/indigo/) — CDX/CDXML loading and PNG/SVG rendering used in Module 9

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -467,6 +467,42 @@ tree.write("output_reaction.cdxml", encoding="unicode", xml_declaration=True)
 print("Edited file saved; arrows and existing text preserved")
 ```
 
+### Workflow 4: Build a multi-step scheme with the bundled helper (recommended)
+
+**Goal**: Turn a list of `(SMILES, name, conditions)` steps into a laid-out scheme
+**and its PNG in one call** — without hand-managing coordinates, object ids, or arrow
+placement. This is the reliable path for anything beyond a single reaction: doing it
+by hand repeatedly produces duplicate ids, arrows emitted twice, and conditions text
+landing on a structure. `scripts/build_reaction_scheme.py` (bundled) does the layout
+mechanically — snake grid, unique ids, conditions centered in the clear gap over each
+arrow — and always writes the `.cdxml` and `.png` together.
+
+```python
+from scripts.build_reaction_scheme import build_scheme  # adjust import path to the skill dir
+
+steps = [
+    {"smiles": "O=C1CCCC1", "name": "cyclopentanone"},
+    # `conditions` = reagents for the arrow LEADING INTO this step (list = stacked lines)
+    {"smiles": "O=C1C(Br)C(Br)C(Br)C1Br", "name": "tetrabromoketone",
+     "conditions": ["Br2 (excess)", "AcOH, 25 C"]},
+    {"smiles": "O=C1C=CC=C1Br", "name": "2-bromocyclopentadienone",
+     "conditions": ["Et2NH", "cold Et2O, -2 HBr"]},
+    {"smiles": "O=C1C2C=CC1(Br)C1(Br)C(=O)C=CC21", "name": "endo dimer",
+     "conditions": ["spontaneous", "Diels-Alder"]},
+    {"smiles": "C12C3C4C1C1C2C3C41", "name": "cubane",
+     "conditions": ["(remaining steps...)"]},
+]
+
+cdxml_path, png_path = build_scheme(
+    steps, "cubane.cdxml", "cubane.png",
+    title="Eaton's Total Synthesis of Cubane (1964)", cols=4)
+print(f"Deliverables: {cdxml_path} + {png_path}")   # hand over BOTH
+```
+
+The helper renders as it builds, so **you can open the PNG, confirm the layout, and
+only then deliver both files** — the render step cannot be forgotten because it is
+part of the same call.
+
 ## Key Parameters
 
 | Parameter | Module / Function | Default | Range / Options | Effect |
@@ -621,6 +657,7 @@ print("CLEAN" if not issues else "ISSUES:\n  " + "\n  ".join(issues))
 ## Bundled Resources
 
 - `references/cdxml-schema-reference.md` — element/attribute cheat-sheet for `n`, `b`, `arrow`, `graphic`, `step`/`scheme`, `t`/`s`, `fonttable`, `colortable`; coordinate conventions; and the `ArrowType`/`GraphicType`/`SymbolType`/font-face enumerations, distilled from the CambridgeSoft CDX/CDXML specification.
+- `scripts/build_reaction_scheme.py` — assemble a multi-step scheme from `(smiles, name, conditions)` steps and render the PNG in one call (Workflow 4). Handles grid layout, globally unique object ids, single arrows, and conditions text placed clear of structures — the defects that recur when schemes are hand-built. Runnable as a library (`build_scheme(...)`) or CLI (`python build_reaction_scheme.py steps.json out.cdxml out.png "Title"`).
 
 ## Related Skills
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "rdkit-chemdraw-cdxml"
-description: "Read, write, and edit ChemDraw CDX/CDXML files with RDKit's rdkit.Chem.rdChemDraw module plus direct XML editing. Parse molecules and reactions from .cdxml/.cdx, write clean molecule structures with good 2D depiction (CoordGen, template alignment), and hand-build or modify the parts RDKit cannot write: reaction arrows, plus signs, reaction schemes/steps, and free text/labels via the CDXML XML schema. Use when generating publication-ready chemical drawings, building reaction schemes programmatically, or modifying existing ChemDraw files. Critical: RDKit writes structures only; round-tripping a reaction through a Mol silently drops arrows and text — this skill shows the XML layer needed to preserve them. For pure molecular analysis (descriptors, fingerprints, SMARTS) use rdkit-cheminformatics; for multi-format 3D conversion use openbabel."
+description: "Read, write, and edit ChemDraw CDX/CDXML files with RDKit's rdkit.Chem.rdChemDraw plus direct XML editing, always paired with a rendered PNG. Parse molecules and reactions from .cdxml/.cdx, write structures with good 2D depiction, and hand-build or modify the parts RDKit cannot write: reaction arrows, plus signs, schemes/steps, and text/labels. Use for reaction schemes, synthesis routes, mechanisms, retrosynthesis, or SI figures. Critical: RDKit writes structures only — round-tripping a reaction through a Mol silently drops arrows and text; this skill shows the XML layer that preserves them. For pure molecular analysis (descriptors, fingerprints, SMARTS) use rdkit-cheminformatics; for multi-format 3D conversion use openbabel."
 license: "BSD-3-Clause"
 ---
 
@@ -8,34 +8,35 @@ license: "BSD-3-Clause"
 
 ## Overview
 
-ChemDraw's native formats are CDX (binary) and CDXML (an XML serialization of the same object tree). RDKit 2022.09+ ships an optional Revvity ChemDraw parser exposed through `rdkit.Chem.rdChemDraw`, which reads molecules **and** reactions from both formats and writes molecule structures. This skill combines that RDKit I/O with direct CDXML XML editing, because RDKit writes only atoms/bonds/coordinates — reaction **arrows**, **plus signs**, **reaction schemes**, and free **text/labels** are ChemDraw canvas objects that must be built or edited at the XML level. The result is a full read → depict → annotate → write → modify workflow for programmatic ChemDraw drawings.
+CDXML is an XML serialization of ChemDraw's object tree (CDX is its binary form). RDKit 2022.09+ exposes an optional Revvity ChemDraw parser at `rdkit.Chem.rdChemDraw` that reads molecules **and** reactions and writes molecule structures. RDKit cannot write **arrows, plus signs, schemes, or text** — those are built or edited at the XML level. This skill covers the full read → depict → annotate → write → modify → render loop.
+
+## Output contract
+
+A `.cdxml` is not viewable without ChemDraw, and **you cannot run ChemDraw here** — so the rendered PNG is the only evidence the file is correct. Therefore:
+
+- **Deliver `<name>.cdxml` and `<name>.png` together, matching basenames** — never the CDXML alone. `build_scheme()` and Module 9 write both; the helper raises if the PNG cannot be produced.
+- **Validate before delivering** with `scripts/check_scheme.py` (rebuilds each molecule from the drawing, sanitizes, checks mass balance across arrows, and critiques layout). Drive it to zero problems.
+- **Report honestly**: "opens correctly in ChemDraw" is never something you tested; stereochemistry is not drawn unless you added it. Offer a plain SMILES list of intermediates for schemes with more than three structures.
 
 ## When to Use
 
-- Convert SMILES/SDF/Mol structures into `.cdxml` files that open cleanly in ChemDraw
-- Extract molecules or reactions (reactants/agents/products) from `.cdxml` or `.cdx` files
-- Build a reaction scheme programmatically: fragments + reaction arrow + `+` separators + conditions text
-- Add captions, atom labels, or annotations to a chemical drawing at specific canvas positions
-- Modify an existing ChemDraw file (relabel a group, add a note, reposition an arrow) without losing its arrows/text
-- Improve the 2D layout of a structure before export (CoordGen, template alignment, straightening)
-- Render a `.cdxml`/`.cdx` to PNG or SVG for a visual quality check of the drawing you generated
+- Convert SMILES/SDF/Mol into `.cdxml` files that open cleanly in ChemDraw
+- Extract molecules or reactions (reactants/agents/products) from `.cdxml` or `.cdx`
+- Build a reaction scheme: fragments + arrows + `+` separators + conditions text
+- Modify an existing ChemDraw file (relabel, annotate, reposition) without losing its arrows/text
 - Batch-generate ChemDraw figures for a reaction dataset or SAR table
-- Use `rdkit-cheminformatics` instead when you only need descriptors, fingerprints, similarity, or SMARTS — no ChemDraw I/O
-- For multi-format 3D structure conversion (MOL2, XYZ, PDB), use `openbabel` instead; this toolkit is 2D ChemDraw-specific
+- Use `rdkit-cheminformatics` instead for descriptors/fingerprints/SMARTS with no ChemDraw I/O
+- For multi-format 3D conversion (MOL2, XYZ, PDB), use `openbabel`; this toolkit is 2D ChemDraw-specific
 
 ## Prerequisites
 
-- **Python packages**: `rdkit` (2023.03+ recommended; must be built with ChemDraw support), `lxml` (optional, for pretty-printing/XPath); `xml.etree.ElementTree` from the stdlib is sufficient for editing. Optional: `epam.indigo` for rendering CDXML to PNG/SVG (Module 9)
-- **Data requirements**: SMILES/Mol objects for writing; `.cdxml` (UTF-8 text) or `.cdx` (binary) files for reading
-- **Environment**: Python 3.9+; verify ChemDraw write support at runtime (see below) — some conda builds omit it
-
-> **Check before installing.** In a managed env (pixi/conda), RDKit is likely already present — run `python -c "import rdkit; print(rdkit.__version__)"` first and skip the install if it succeeds. Inside a pixi project, run scripts with `pixi run python ...`.
+- **Python packages**: `rdkit` (2023.03+, built with ChemDraw support), `epam.indigo` (renders CDXML→PNG); `xml.etree.ElementTree` (stdlib) handles all XML editing.
+- **Inputs**: SMILES/Mol for writing; `.cdxml` (UTF-8 text) or `.cdx` (binary) for reading.
+- **Check before installing.** RDKit is usually already present in a managed env — run `python -c "import rdkit"` first; inside pixi use `pixi run python ...`.
 
 ```bash
-# Only if RDKit is not already available:
-pip install rdkit lxml
-# Then confirm the optional ChemDraw parser is compiled in:
-python -c "from rdkit import Chem; print('ChemDraw support:', Chem.HasChemDrawCDXSupport())"
+pip install rdkit epam.indigo   # only if missing
+python -c "from rdkit import Chem; print('ChemDraw write support:', Chem.HasChemDrawCDXSupport())"
 ```
 
 ## Quick Start
@@ -44,270 +45,173 @@ python -c "from rdkit import Chem; print('ChemDraw support:', Chem.HasChemDrawCD
 from rdkit import Chem
 from rdkit.Chem import rdChemDraw, rdDepictor
 
-mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")  # aspirin
-rdDepictor.SetPreferCoordGen(True)                  # nicer layouts
-rdDepictor.Compute2DCoords(mol)                     # coordinates are REQUIRED before writing
-
-cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)  # -> str
-with open("aspirin.cdxml", "w", encoding="utf-8") as fh:
-    fh.write(cdxml)
-print(f"Wrote {len(cdxml)} chars of CDXML")
+mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")   # aspirin
+rdDepictor.SetPreferCoordGen(True)
+rdDepictor.Compute2DCoords(mol)                      # coordinates are REQUIRED before writing
+cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)   # -> str
+open("aspirin.cdxml", "w", encoding="utf-8").write(cdxml)
 ```
 
 ## Core API
 
 ### Module 1: Reading molecules
 
-`MolsFromChemDrawFile` / `MolsFromChemDrawBlock` handle **both** `.cdx` and `.cdxml` and return a tuple of `Mol` objects (one per fragment on the page).
+`MolsFromChemDrawFile` / `MolsFromChemDrawBlock` handle both `.cdx` and `.cdxml`, returning a tuple of `Mol` (one per fragment).
 
 ```python
 from rdkit import Chem
 from rdkit.Chem import rdChemDraw
 
-# From a file (.cdxml or .cdx — format auto-detected)
 mols = rdChemDraw.MolsFromChemDrawFile("drawing.cdxml", sanitize=True, removeHs=True)
-print(f"Parsed {len(mols)} molecule(s)")
 for m in mols:
-    print("  ", Chem.MolToSmiles(m))
+    print(Chem.MolToSmiles(m))
 
-# From an in-memory block (str for CDXML, bytes for CDX)
 block = open("drawing.cdxml", encoding="utf-8").read()
 mols = rdChemDraw.MolsFromChemDrawBlock(block, sanitize=True, removeHs=True)
-
-# Legacy CDXML-only parser (no ChemDraw SDK needed) as a fallback:
-mols_legacy = Chem.MolsFromCDXML(block, sanitize=True, removeHs=True)
+mols_legacy = Chem.MolsFromCDXML(block)   # CDXML-only fallback, no ChemDraw SDK needed
 ```
 
 ### Module 2: Reading reactions (arrows → reactant/product split)
 
-Arrows in ChemDraw carry the reaction semantics. `ReactionsFromChemDrawBlock` interprets `<step>`/`<arrow>` objects and returns `ChemicalReaction`s with reactants, agents, and products split out.
+`ReactionsFromChemDrawBlock` interprets `<step>`/`<arrow>` and returns `ChemicalReaction`s with reactants, agents, and products split out. Note the reaction reader defaults `sanitize=False`.
 
 ```python
+from rdkit import Chem
 from rdkit.Chem import rdChemDraw, rdChemReactions
 
 block = open("reaction.cdxml", encoding="utf-8").read()
-
-# Note: reaction reader defaults sanitize=False, removeHs=False
-rxns = rdChemDraw.ReactionsFromChemDrawBlock(block, sanitize=True, removeHs=False)
-for rxn in rxns:
+for rxn in rdChemDraw.ReactionsFromChemDrawBlock(block, sanitize=True):
     print("reactants:", [Chem.MolToSmiles(m) for m in rxn.GetReactants()])
-    print("agents   :", [Chem.MolToSmiles(m) for m in rxn.GetAgents()])
     print("products :", [Chem.MolToSmiles(m) for m in rxn.GetProducts()])
 
-# CDXML-only equivalent (legacy parser):
-rxns2 = rdChemReactions.ReactionsFromCDXMLBlock(block, sanitize=True, removeHs=False)
+rxns = rdChemReactions.ReactionsFromCDXMLBlock(block, sanitize=True)   # legacy equivalent
 ```
 
 ### Module 3: Writing molecule structures
 
-`MolToChemDrawBlock` writes one molecule. **CDXML returns `str`; CDX write is unreliable in `rdChemDraw`** (raises `UnicodeDecodeError`), so use the legacy writer for binary CDX bytes.
+`MolToChemDrawBlock` writes one molecule to CDXML (`str`). CDX (binary) write is broken in `rdChemDraw` (`UnicodeDecodeError`); use the legacy writer for CDX bytes.
 
 ```python
 from rdkit import Chem
-from rdkit.Chem import rdChemDraw, rdDepictor
-from rdkit.Chem import rdmolfiles
+from rdkit.Chem import rdChemDraw, rdDepictor, rdmolfiles
 
 mol = Chem.MolFromSmiles("c1ccccc1O")
-rdDepictor.Compute2DCoords(mol)                      # always compute coords first
-
-# CDXML (text) — preferred, works in both writers
-cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)   # str
-
-# CDX (binary) — use the LEGACY writer; rdChemDraw's CDX path is broken
-cdx_bytes = Chem.MolToCDXMLBlock(mol, rdmolfiles.CDXMLFormat.CDX)        # bytes
-with open("phenol.cdx", "wb") as fh:
-    fh.write(cdx_bytes)
-
-if not Chem.HasChemDrawCDXSupport():
-    raise RuntimeError("This RDKit build lacks ChemDraw write support")
+rdDepictor.Compute2DCoords(mol)                                          # coords first, always
+cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)   # str (preferred)
+cdx_bytes = Chem.MolToCDXMLBlock(mol, rdmolfiles.CDXMLFormat.CDX)        # bytes (legacy writer)
 ```
 
 ### Module 4: Good molecular depiction
 
-Layout quality is set *before* you write. CoordGen gives more natural, less-overlapping 2D coordinates than the default algorithm; template alignment keeps a common scaffold oriented consistently across a series.
+Layout quality is set *before* writing. CoordGen gives more natural coordinates; template alignment keeps a shared scaffold oriented consistently across a series. Note: CoordGen still tangles cages and bridged bicyclics — check those in the render.
 
 ```python
 from rdkit import Chem
 from rdkit.Chem import rdDepictor
-from rdkit.Chem import AllChem
 
-# 1) Prefer CoordGen globally for publication-like layouts
 rdDepictor.SetPreferCoordGen(True)
-
 mol = Chem.MolFromSmiles("O=C(Nc1ccc(cc1)S(=O)(=O)N)C")
 rdDepictor.Compute2DCoords(mol)
-
-# 2) Clean up: straighten rings/bonds and normalize bond length to a target
 rdDepictor.StraightenDepiction(mol)
-rdDepictor.NormalizeDepiction(mol)      # scales so the median bond length is uniform
+rdDepictor.NormalizeDepiction(mol)      # uniform median bond length
 ```
 
 ```python
-# 3) Align a series to a shared scaffold so the core is drawn identically each time
-template = Chem.MolFromSmiles("c1ccc(cc1)S(=O)(=O)N")  # sulfonamide core
+# Align a series to a shared scaffold so the core is drawn identically each time
+template = Chem.MolFromSmiles("c1ccc(cc1)S(=O)(=O)N")
 rdDepictor.Compute2DCoords(template)
-
-series = [Chem.MolFromSmiles(s) for s in
-          ["Cc1ccc(cc1)S(=O)(=O)N", "Clc1ccc(cc1)S(=O)(=O)N"]]
-for m in series:
-    rdDepictor.GenerateDepictionMatching2DStructure(m, template)  # core aligned
-    print(Chem.MolToSmiles(m), "aligned to template")
+for m in [Chem.MolFromSmiles(s) for s in ["Cc1ccc(cc1)S(=O)(=O)N", "Clc1ccc(cc1)S(=O)(=O)N"]]:
+    rdDepictor.GenerateDepictionMatching2DStructure(m, template)
 ```
 
 ### Module 5: Drawing arrows
 
-RDKit cannot write arrows, so build them in CDXML. A reaction arrow is an `<arrow>` object with `Head3D`/`Tail3D` positions (`"x y z"`, y increases downward). The `ArrowheadHead`/`ArrowheadType` attributes control the head; `HeadSize` is in CDXML units (~1000/unit typical).
+A reaction arrow is an `<arrow>` with `Head3D`/`Tail3D` (`"x y z"`, y increases downward). `ArrowheadHead`/`ArrowheadType` style the head. Equilibrium/resonance/retrosynthetic arrows use a `<graphic>` Line with `ArrowType`.
 
 ```python
 import xml.etree.ElementTree as ET
 
-def make_arrow(arrow_id, tail_xy, head_xy, kind="Full"):
-    """Straight reaction arrow. kind: 'Full' (reaction), 'None' (line)."""
-    tx, ty = tail_xy
-    hx, hy = head_xy
-    arrow = ET.Element("arrow", {
-        "id": str(arrow_id),
+def make_arrow(arrow_id, tail_xy, head_xy):
+    (tx, ty), (hx, hy) = tail_xy, head_xy
+    return ET.Element("arrow", {
+        "id": str(arrow_id), "FillType": "None", "ArrowheadType": "Solid",
+        "ArrowheadHead": "Full", "HeadSize": "2250",
         "BoundingBox": f"{min(tx,hx)} {min(ty,hy)-4} {max(tx,hx)} {max(ty,hy)+4}",
-        "FillType": "None",
-        "ArrowheadType": "Solid",
-        "ArrowheadHead": kind,          # 'Full', 'HalfLeft', 'HalfRight', 'None'
-        "HeadSize": "2250",
-        "Head3D": f"{hx} {hy} 0",
-        "Tail3D": f"{tx} {ty} 0",
-    })
-    return arrow
+        "Head3D": f"{hx} {hy} 0", "Tail3D": f"{tx} {ty} 0"})
 
 print(ET.tostring(make_arrow(40, (160, 100), (210, 100)), encoding="unicode"))
-# Equilibrium/resonance/retrosynthetic arrows: use a <graphic> Line with ArrowType
 equil = ET.Element("graphic", {"id": "41", "GraphicType": "Line",
-                               "ArrowType": "Equilibrium", "HeadSize": "2250",
-                               "BoundingBox": "160 100 210 100"})
+                               "ArrowType": "Equilibrium", "BoundingBox": "160 100 210 100"})
 ```
 
 ### Module 6: Reaction schemes and steps
 
-A `<scheme>` groups one or more `<step>` objects. Each `<step>` references other objects **by id**: `ReactionStepReactants`, `ReactionStepProducts`, `ReactionStepArrows`, `ReactionStepPlusses`, and objects above/below the arrow (for conditions). Fragments and the arrow live on the `<page>`; the step just wires their ids together.
+A `<scheme>` groups `<step>` objects that reference page objects **by id**: `ReactionStepReactants`, `ReactionStepProducts`, `ReactionStepArrows`, `ReactionStepPlusses`, and objects above/below the arrow.
 
 ```python
 import xml.etree.ElementTree as ET
 
-# Plus sign between two reactants (a Symbol graphic)
 def make_plus(gid, x, y):
     return ET.Element("graphic", {"id": str(gid), "GraphicType": "Symbol",
-                                  "SymbolType": "Plus",
-                                  "BoundingBox": f"{x} {y-7} {x+15} {y+8}"})
+                                  "SymbolType": "Plus", "BoundingBox": f"{x} {y-7} {x+15} {y+8}"})
 
-# Wire reactant/product/arrow ids into one reaction step
-step = ET.Element("step", {
-    "id": "61",
-    "ReactionStepReactants": "10 20",     # fragment ids, space-separated
-    "ReactionStepProducts": "50",
-    "ReactionStepArrows": "40",
-    "ReactionStepPlusses": "30",
-    "ReactionStepObjectsAboveArrow": "70",  # e.g. a text id for conditions
-})
 scheme = ET.Element("scheme", {"id": "60"})
-scheme.append(step)
+ET.SubElement(scheme, "step", {"id": "61", "ReactionStepReactants": "10 20",
+    "ReactionStepProducts": "50", "ReactionStepArrows": "40",
+    "ReactionStepPlusses": "30", "ReactionStepObjectsAboveArrow": "70"})
 print(ET.tostring(scheme, encoding="unicode"))
 ```
 
 ### Module 7: Adding text and labels
 
-Free text is a `<t>` object positioned by `p="x y"`, containing one or more `<s>` styled-string children. Each `<s>` references a `font` id (from `<fonttable>`) and a `color` index (from `<colortable>`); `size` is in points and `face` is a style bitmask (1=bold, 2=italic, 4=underline; e.g. `96` = subscript/superscript flags used by ChemDraw).
+Free text is a `<t>` at `p="x y"` holding one or more `<s>` styled-string children. `<s>` references a `font` id (`<fonttable>`) and `color` index (`<colortable>`); `face` is a bitmask (1=bold, 2=italic, 32=subscript, 64=superscript). Split a `<t>` into multiple `<s>` runs for subscripts (`Br₂`, `CO₂H`). **Keep text ASCII** — the font table is iso-8859-1, so write `hv` not `hν`, `25 C` not `25 °C`, `heat` not `Δ`.
 
 ```python
 import xml.etree.ElementTree as ET
 
-def make_fonttable(font_id=21, name="Helvetica"):
-    ft = ET.Element("fonttable")
-    ET.SubElement(ft, "font", {"id": str(font_id), "charset": "x-mac-roman", "name": name})
-    return ft
-
-def make_colortable():
-    ct = ET.Element("colortable")
-    for r, g, b in [(1, 1, 1), (0, 0, 0)]:   # index 0=white(bg), then black...
-        ET.SubElement(ct, "color", {"r": str(r), "g": str(g), "b": str(b)})
-    return ct
-
-def make_text(tid, x, y, text, font_id=21, size=10, color=0, face=0):
-    t = ET.Element("t", {"id": str(tid), "p": f"{x} {y}"})
-    s = ET.SubElement(t, "s", {"font": str(font_id), "size": str(size),
-                               "color": str(color), "face": str(face)})
-    s.text = text
-    return t
-
-print(ET.tostring(make_text(70, 175, 92, "reflux, 2 h"), encoding="unicode"))
-```
-
-Chemical formulas need **subscripts/superscripts**, which ChemDraw renders by
-splitting a `<t>` into multiple `<s>` runs with different `face` bitmasks
-(`32`=subscript, `64`=superscript). One run per style change:
-
-```python
-import xml.etree.ElementTree as ET
-
-def make_formula(tid, x, y, runs, font_id=3, size=8.5):
-    """runs: list of (text, face). face 0=normal, 32=subscript, 64=superscript."""
+def make_text(tid, x, y, runs, font_id=21, size=10):
+    """runs: list of (text, face). face 0=normal, 1=bold, 32=subscript, 64=superscript."""
     t = ET.Element("t", {"id": str(tid), "p": f"{x} {y}"})
     for text, face in runs:
-        s = ET.SubElement(t, "s", {"font": str(font_id), "size": str(size),
-                                   "color": "0", "face": str(face)})
-        s.text = text
+        ET.SubElement(t, "s", {"font": str(font_id), "size": str(size),
+                               "color": "0", "face": str(face)}).text = text
     return t
 
-# "Br2 (excess)"  ->  Br<sub>2</sub> (excess)
-print(ET.tostring(make_formula(80, 158, 135,
-      [("Br", 0), ("2", 32), (" (excess)", 0)]), encoding="unicode"))
-# "CO2H" -> CO<sub>2</sub>H
-print(ET.tostring(make_formula(81, 690, 730,
-      [("-CO", 0), ("2", 32), ("H", 0)]), encoding="unicode"))
+print(ET.tostring(make_text(70, 175, 92, [("reflux, 2 h", 0)]), encoding="unicode"))
+print(ET.tostring(make_text(80, 158, 135, [("Br", 0), ("2", 32), (" (excess)", 0)]),
+                  encoding="unicode"))   # Br<sub>2</sub> (excess)
 ```
 
 ### Module 8: Editing an existing CDXML file
 
-Because CDXML is generic XML, `ElementTree` round-trips arrows, text, and graphics it does not "understand" — so you can load a real ChemDraw file, tweak it, and save without losing objects. (RDKit's Mol round-trip would drop them.)
+`ElementTree` round-trips arrows, text, and graphics it does not understand, so you can edit a real ChemDraw file without losing objects — unlike an RDKit Mol round-trip.
 
 ```python
 import xml.etree.ElementTree as ET
 
 tree = ET.parse("reaction.cdxml")          # DOCTYPE is dropped on re-save (harmless)
 root = tree.getroot()
-page = root.find("page")
-
-# Relabel every "Cl" text object to "Br"
-for t in root.iter("t"):
-    for s in t.iter("s"):
-        if s.text == "Cl":
-            s.text = "Br"
-
-# Append a caption; reuse the file's existing font/color tables
-cap = ET.SubElement(page, "t", {"p": "100 300"})
+for s in root.iter("s"):                   # relabel "Cl" -> "Br"
+    if s.text == "Cl":
+        s.text = "Br"
+cap = ET.SubElement(root.find("page"), "t", {"p": "100 300"})
 ET.SubElement(cap, "s", {"font": "21", "size": "12", "color": "0"}).text = "Scheme 1"
-
 tree.write("reaction_edited.cdxml", encoding="unicode", xml_declaration=True)
-print("Saved reaction_edited.cdxml")
 ```
 
-### Module 9: Rendering CDXML to PNG (paired deliverable + visual QA)
+### Module 9: Rendering CDXML to PNG
 
-CDXML is not human-viewable on its own, so **a `.cdxml` should never be handed
-over alone — always deliver it together with a rendered `.png` (or `.svg`) of the
-same drawing.** The image serves two purposes: it is what the user actually looks
-at, and it is your own fastest check for overlapping structures, stray arrows
-(from duplicate/degenerate arrow ids), and text colliding with atoms. Render the
-PNG next to the CDXML (same basename), verify it visually, then provide both files.
-[Indigo](https://lifescience.opensource.epam.com/indigo/) (`epam.indigo`, renderer
-bundled) loads a CDXML — a scheme with arrows as a *reaction*, a lone structure as
-a *molecule* — and rasterizes arrows, text, and layout faithfully.
+Render the PNG next to the CDXML (same basename), look at it, then deliver both. [Indigo](https://lifescience.opensource.epam.com/indigo/) (`epam.indigo`) loads a CDXML — a scheme with arrows as a *reaction*, a lone structure as a *molecule* — and rasterizes arrows, text, and layout faithfully. (RDKit's own `Draw.ReactionToImage` re-lays-out molecules and drops the ChemDraw arrows/text, so use Indigo to render a file as authored.)
 
 ```python
+from pathlib import Path
 from indigo import Indigo
 from indigo.renderer import IndigoRenderer
 
-def render_cdxml(cdxml_path, png_path, width=1600):
-    ind = Indigo()
-    rnd = IndigoRenderer(ind)
-    ind.setOption("render-output-format", "png")   # or "svg"
+def render_cdxml(cdxml_path, png_path=None, width=1600):
+    png_path = png_path or str(Path(cdxml_path).with_suffix(".png"))
+    ind = Indigo(); rnd = IndigoRenderer(ind)
+    ind.setOption("render-output-format", "png")
     ind.setOption("render-background-color", "1,1,1")
     ind.setOption("render-image-width", width)
     cdxml = open(cdxml_path, encoding="utf-8").read()
@@ -318,27 +222,17 @@ def render_cdxml(cdxml_path, png_path, width=1600):
     rnd.renderToFile(obj, png_path)
     return png_path
 
-# Render the PNG as a sibling of the CDXML, then deliver BOTH files together
-from pathlib import Path
-src = "scheme.cdxml"
-png = str(Path(src).with_suffix(".png"))
-render_cdxml(src, png)
-print(f"Deliverables: {src} + {png}")
+print("Wrote", render_cdxml("scheme.cdxml"))
 ```
-
-RDKit can also draw a *parsed* reaction (`Draw.ReactionToImage(rxn)`), but it
-re-lays-out the molecules and drops the original ChemDraw arrows/text/positions —
-use Indigo when you want the file rendered as authored.
 
 ## Key Concepts
 
 ### CDXML coordinate system
 
-Positions use ChemDraw units where **y increases downward** (origin top-left). Atom positions are `p="x y"`; arrows use `Head3D`/`Tail3D="x y z"`; graphics and text carry a `BoundingBox="x1 y1 x2 y2"`. The default bond length is ~30 units. RDKit sometimes emits `<CDXML BondLength="">` (empty) — set a numeric `BondLength` (e.g. `"30"`) on the root when assembling files so ChemDraw scales sanely.
+**y increases downward** (origin top-left). Atoms: `p="x y"`; arrows: `Head3D`/`Tail3D="x y z"`; graphics/text: `BoundingBox="x1 y1 x2 y2"`. Default bond length ≈ 30.
 
 ```python
-# Shift a fragment's atoms by (dx, dy) to position it on the canvas
-def shift_fragment(frag, dx, dy):
+def shift_fragment(frag, dx, dy):      # move a fragment onto the canvas
     for n in frag.iter("n"):
         x, y = map(float, n.get("p").split())
         n.set("p", f"{x+dx} {y+dy}")
@@ -347,24 +241,20 @@ def shift_fragment(frag, dx, dy):
 
 ### Object-id reference model
 
-Every object has a unique integer `id`. Reactions, groups, and brackets refer to their members **by id** rather than by nesting. When you merge fragments from separate RDKit outputs into one page, **renumber all ids to keep them globally unique**, then wire the reaction `<step>` to the new ids.
+Every object has a unique integer `id`; reactions and groups reference members **by id**, not by nesting. When merging fragments from separate RDKit outputs (each starts ids at 1), renumber all ids to stay globally unique, then wire `<step>` to the new ids.
 
 ### RDKit vs XML capability boundary
 
 | Task | RDKit `rdChemDraw` | Direct XML |
 |------|--------------------|-----------|
-| Read molecules | ✅ | — |
-| Read reactions (arrows) | ✅ | — |
+| Read molecules / reactions | ✅ | — |
 | Write molecule structure | ✅ (CDXML) | — |
-| Write arrows / plus / scheme | ❌ | ✅ |
-| Write text / captions | ❌ | ✅ |
+| Write arrows / plus / scheme / text | ❌ | ✅ |
 | Preserve objects while editing | ❌ (drops on Mol round-trip) | ✅ |
 
 ## Common Workflows
 
-### Workflow 1: SMILES → cleanly depicted single-molecule CDXML
-
-**Goal**: Produce a ChemDraw file for one structure with a good 2D layout.
+### Workflow 1: SMILES → single-molecule CDXML
 
 ```python
 from rdkit import Chem
@@ -377,17 +267,15 @@ def smiles_to_cdxml(smiles, path):
     rdDepictor.SetPreferCoordGen(True)
     rdDepictor.Compute2DCoords(mol)
     rdDepictor.StraightenDepiction(mol)
-    cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)
-    with open(path, "w", encoding="utf-8") as fh:
-        fh.write(cdxml)
+    open(path, "w", encoding="utf-8").write(rdChemDraw.MolToChemDrawBlock(mol))
     return path
 
 print("Wrote", smiles_to_cdxml("CC(=O)Oc1ccccc1C(=O)O", "aspirin.cdxml"))
 ```
 
-### Workflow 2: Build a full reaction scheme CDXML (arrow + plus + conditions)
+### Workflow 2: Hand-assemble a reaction from Modules 5-7
 
-**Goal**: Assemble two reactants, a product, a reaction arrow, a `+` separator, and a text condition into one valid CDXML that ChemDraw opens and RDKit re-parses as a reaction.
+Combine `_fragment_of` (write a mol, extract `<fragment>`, renumber ids, shift x) with an arrow, a plus, conditions text, and a `<step>`. Render with Module 9. For multi-step schemes prefer Workflow 4.
 
 ```python
 from rdkit import Chem
@@ -395,294 +283,155 @@ from rdkit.Chem import rdChemDraw, rdDepictor, rdChemReactions
 import xml.etree.ElementTree as ET
 
 def _fragment_of(smiles, base_id, dx):
-    """Write one molecule to CDXML, extract its <fragment>, renumber ids, shift x."""
     m = Chem.MolFromSmiles(smiles); rdDepictor.Compute2DCoords(m)
     frag = ET.fromstring(rdChemDraw.MolToChemDrawBlock(m)).find("page/fragment")
     remap = {}
     for i, el in enumerate([frag, *frag.iter("n"), *frag.iter("b")]):
-        old = el.get("id"); remap[old] = str(base_id + i); el.set("id", remap[old])
-    for b in frag.iter("b"):                 # fix bond endpoint references
+        remap[el.get("id")] = str(base_id + i); el.set("id", remap[el.get("id")])
+    for b in frag.iter("b"):
         b.set("B", remap[b.get("B")]); b.set("E", remap[b.get("E")])
-    for n in frag.iter("n"):                 # shift onto the canvas
+    for n in frag.iter("n"):
         x, y = map(float, n.get("p").split()); n.set("p", f"{x+dx} {y}")
     return frag
 
-root = ET.Element("CDXML", {"BondLength": "30"})
-page = ET.SubElement(root, "page")
-
-r1 = _fragment_of("CCO", 100, 0);      page.append(r1)      # reactant 1
-plus = ET.SubElement(page, "graphic", {"id": "30", "GraphicType": "Symbol",
-                                       "SymbolType": "Plus", "BoundingBox": "60 -7 75 8"})
-r2 = _fragment_of("CC(=O)O", 200, 120); page.append(r2)     # reactant 2
-arrow = ET.SubElement(page, "arrow", {"id": "40", "FillType": "None",
-        "ArrowheadHead": "Full", "ArrowheadType": "Solid", "HeadSize": "2250",
-        "BoundingBox": "260 0 320 7", "Head3D": "320 3 0", "Tail3D": "260 3 0"})
+root = ET.Element("CDXML", {"BondLength": "30"}); page = ET.SubElement(root, "page")
+page.append(_fragment_of("CCO", 100, 0))
+ET.SubElement(page, "graphic", {"id": "30", "GraphicType": "Symbol",
+                                "SymbolType": "Plus", "BoundingBox": "60 -7 75 8"})
+page.append(_fragment_of("CC(=O)O", 200, 120))
+ET.SubElement(page, "arrow", {"id": "40", "FillType": "None", "ArrowheadHead": "Full",
+    "ArrowheadType": "Solid", "HeadSize": "2250", "Head3D": "320 3 0", "Tail3D": "260 3 0"})
 cond = ET.SubElement(page, "t", {"id": "70", "p": "270 -12"})
 ET.SubElement(cond, "s", {"font": "21", "size": "9", "color": "0"}).text = "H+, reflux"
-prod = _fragment_of("CCOC(C)=O", 300, 420); page.append(prod)  # product (clear of arrow)
-
+page.append(_fragment_of("CCOC(C)=O", 300, 420))
 scheme = ET.SubElement(page, "scheme", {"id": "60"})
 ET.SubElement(scheme, "step", {"id": "61", "ReactionStepReactants": "100 200",
-        "ReactionStepProducts": "300", "ReactionStepArrows": "40",
-        "ReactionStepPlusses": "30", "ReactionStepObjectsAboveArrow": "70"})
-ft = ET.SubElement(root, "fonttable")
-ET.SubElement(ft, "font", {"id": "21", "charset": "x-mac-roman", "name": "Helvetica"})
+    "ReactionStepProducts": "300", "ReactionStepArrows": "40", "ReactionStepPlusses": "30"})
+ET.SubElement(ET.SubElement(root, "fonttable"), "font",
+              {"id": "21", "charset": "x-mac-roman", "name": "Helvetica"})
 
 cdxml = ET.tostring(root, encoding="unicode")
 open("esterification.cdxml", "w", encoding="utf-8").write(cdxml)
-
-# Verify: RDKit should re-parse it as a reaction
-rxns = rdChemReactions.ReactionsFromCDXMLBlock(cdxml, sanitize=True)
-print("Re-parsed reactions:", len(rxns))
-
-# Deliverable pair: render a PNG next to the CDXML (see Module 9) and hand over both
-from indigo import Indigo
-from indigo.renderer import IndigoRenderer
-ind = Indigo(); rnd = IndigoRenderer(ind)
-ind.setOption("render-output-format", "png"); ind.setOption("render-image-width", 1600)
-rnd.renderToFile(ind.loadReaction(cdxml), "esterification.png")
-print("Deliverables: esterification.cdxml + esterification.png")
+print("reactions re-parsed:", len(rdChemReactions.ReactionsFromCDXMLBlock(cdxml, sanitize=True)))
 ```
 
-### Workflow 3: Modify an existing ChemDraw file, preserving arrows and text
-
-**Goal**: Open a reaction someone drew, add an annotation and rescale, and save — without the arrow/text loss an RDKit Mol round-trip would cause.
+### Workflow 3: Edit an existing file, preserving arrows and text
 
 ```python
 import xml.etree.ElementTree as ET
 
-tree = ET.parse("input_reaction.cdxml")
-root = tree.getroot()
-page = root.find("page")
-
-# Add a scheme title above the drawing
-title = ET.SubElement(page, "t", {"p": "50 -30"})
+tree = ET.parse("input_reaction.cdxml"); root = tree.getroot()
+title = ET.SubElement(root.find("page"), "t", {"p": "50 -30"})
 ET.SubElement(title, "s", {"font": "21", "size": "14", "color": "0", "face": "1"}).text = "Route A"
-
-# Bump every arrow's head size so it reads at print scale
 for arrow in root.iter("arrow"):
     arrow.set("HeadSize", "3000")
-
 tree.write("output_reaction.cdxml", encoding="unicode", xml_declaration=True)
-print("Edited file saved; arrows and existing text preserved")
 ```
 
-### Workflow 4: Build a multi-step scheme with the bundled helper (recommended)
+### Workflow 4: Multi-step scheme with the bundled helper (recommended)
 
-**Goal**: Turn a list of `(SMILES, name, conditions)` steps into a laid-out scheme
-**and its PNG in one call** — without hand-managing coordinates, object ids, or arrow
-placement. This is the reliable path for anything beyond a single reaction: doing it
-by hand repeatedly produces duplicate ids, arrows emitted twice, and conditions text
-landing on a structure. `scripts/build_reaction_scheme.py` (bundled) does the layout
-mechanically — snake grid, unique ids, conditions centered in the clear gap over each
-arrow — and always writes the `.cdxml` and `.png` together.
+`scripts/build_reaction_scheme.py` turns `(smiles, name, conditions)` steps into a laid-out scheme **and its PNG in one call**, handling grid layout, globally unique ids, single arrows, and conditions text placed clear of structures — the defects that recur when schemes are hand-built. Cells auto-size to the largest structure, so big molecules never overlap. Model convergent/multi-component steps by folding co-reactants into `conditions` (e.g. `["+ (MeO2C)2C=CHOMe", "Base, MeCN"]`), keeping one main-chain structure per cell.
+
+The `scripts/` files are **not on the execution environment's import path** — copy the two you need into your working directory first (read each with `read_file` from the skill's `scripts/` dir and write it beside your code), then import:
 
 ```python
-from scripts.build_reaction_scheme import build_scheme  # adjust import path to the skill dir
+# after copying build_reaction_scheme.py and check_scheme.py into the workdir:
+from build_reaction_scheme import build_scheme
+from check_scheme import check_all
 
 steps = [
     {"smiles": "O=C1CCCC1", "name": "cyclopentanone"},
-    # `conditions` = reagents for the arrow LEADING INTO this step (list = stacked lines)
     {"smiles": "O=C1C(Br)C(Br)C(Br)C1Br", "name": "tetrabromoketone",
-     "conditions": ["Br2 (excess)", "AcOH, 25 C"]},
+     "conditions": ["Br2 (excess)", "AcOH, 25 C"]},          # reagents for the arrow into this step
     {"smiles": "O=C1C=CC=C1Br", "name": "2-bromocyclopentadienone",
-     "conditions": ["Et2NH", "cold Et2O, -2 HBr"]},
-    {"smiles": "O=C1C2C=CC1(Br)C1(Br)C(=O)C=CC21", "name": "endo dimer",
-     "conditions": ["spontaneous", "Diels-Alder"]},
-    {"smiles": "C12C3C4C1C1C2C3C41", "name": "cubane",
-     "conditions": ["(remaining steps...)"]},
+     "conditions": ["Et2NH", "cold Et2O"]},
+    {"smiles": "C12C3C4C1C5C2C3C45", "name": "cubane", "conditions": ["(remaining steps)"]},
 ]
-
-cdxml_path, png_path = build_scheme(
-    steps, "cubane.cdxml", "cubane.png",
-    title="Eaton's Total Synthesis of Cubane (1964)", cols=4)
-print(f"Deliverables: {cdxml_path} + {png_path}")   # hand over BOTH
+cdxml, png = build_scheme(steps, "cubane.cdxml", title="Total Synthesis of Cubane", cols=4)
+check_all("cubane.cdxml", expect={3: "C12C3C4C1C5C2C3C45"})   # validate before delivering
+print(f"Deliverables: {cdxml} + {png}")
 ```
-
-The helper renders as it builds, so **you can open the PNG, confirm the layout, and
-only then deliver both files** — the render step cannot be forgotten because it is
-part of the same call.
-
-Two things to know:
-
-- **Cells auto-size to the largest structure**, so big molecules (fused rings,
-  sulfonyl groups) never overlap their neighbours. This is the failure mode of
-  hand-placed coordinates — large structures collide because the spacing was
-  guessed. Let the helper compute spacing instead of hardcoding positions.
-- **Model convergent / multi-component steps by folding co-reactants into the
-  `conditions` text** (e.g. `conditions=["+ (MeO2C)2C=CHOMe", "Base, MeCN"]`),
-  keeping one main-chain structure per cell. The helper lays out a linear main
-  chain; drawing every co-reactant as a separate `+` structure is what pushes
-  people back to hand-building overlapping layouts. If a co-reactant must be
-  drawn, add it as its own step with an empty arrow, or place it with the raw
-  XML from Modules 5-7 after the main chain is built.
 
 ## Key Parameters
 
-| Parameter | Module / Function | Default | Range / Options | Effect |
-|-----------|-------------------|---------|-----------------|--------|
-| `format` | `MolToChemDrawBlock` | `CDXFormat.CDXML` | `CDXML`, `CDX` | Output format; use CDXML (str). For CDX bytes use legacy `MolToCDXMLBlock` |
-| `sanitize` | `MolsFromChemDrawBlock` | `True` | `True`/`False` | Sanitize parsed mols; set `False` to inspect raw/invalid input |
-| `removeHs` | `MolsFromChemDrawBlock` | `True` | `True`/`False` | Convert explicit H to implicit |
-| `sanitize` | `ReactionsFromChemDrawBlock` | `False` | `True`/`False` | Reaction reader defaults **False** — pass `True` for clean SMILES |
-| CoordGen | `rdDepictor.SetPreferCoordGen` | `False` | `True`/`False` | `True` gives more natural 2D layouts |
-| `ArrowheadHead` | `<arrow>` XML | — | `Full`, `HalfLeft`, `HalfRight`, `None` | Arrowhead style on the reaction arrow |
-| `ArrowType` | `<graphic>` Line XML | — | `FullHead`, `Equilibrium`, `Resonance`, `RetroSynthetic`, `NoGo` | Special arrow semantics (equilibrium, retrosynthesis, failed) |
-| `BondLength` | `<CDXML>` root XML | `""` (RDKit) | numeric, e.g. `30` | Canvas scale; set explicitly to avoid ChemDraw scaling glitches |
+| Parameter | Module / Function | Default | Options | Effect |
+|-----------|-------------------|---------|---------|--------|
+| `format` | `MolToChemDrawBlock` | `CDXFormat.CDXML` | `CDXML`, `CDX` | Use CDXML (str); for CDX bytes use legacy `MolToCDXMLBlock` |
+| `sanitize` | `MolsFromChemDrawBlock` | `True` | `True`/`False` | `False` to inspect raw/invalid input |
+| `sanitize` | `ReactionsFromChemDrawBlock` | `False` | `True`/`False` | Defaults **False** — pass `True` for clean SMILES |
+| `SetPreferCoordGen` | `rdDepictor` | `False` | `True`/`False` | `True` gives more natural 2D layouts |
+| `ArrowheadHead` | `<arrow>` XML | — | `Full`, `HalfLeft`, `HalfRight`, `None` | Arrowhead style |
+| `ArrowType` | `<graphic>` Line | — | `FullHead`, `Equilibrium`, `Resonance`, `RetroSynthetic`, `NoGo` | Special arrow semantics |
+| `BondLength` | `<CDXML>` root | `""` (RDKit) | numeric, e.g. `30` | Canvas scale; set a number so structures/arrows scale together |
 
 ## Best Practices
 
-1. **Always compute 2D coordinates before writing.** `MolToChemDrawBlock` serializes existing conformer coordinates; without `Compute2DCoords` you get a degenerate layout.
-   ```python
-   rdDepictor.SetPreferCoordGen(True); rdDepictor.Compute2DCoords(mol)
-   ```
-
-2. **Never round-trip a reaction through an RDKit `Mol`/`ChemicalReaction` if you need to keep the drawing.** Reading loses arrows, plus signs, text, and graphics. To *edit* a reaction file, work on the XML tree (Module 8), not on parsed objects.
-
-3. **Set a numeric `BondLength` on the CDXML root when assembling files by hand.** RDKit emits `BondLength=""`, which can make ChemDraw render structures at the wrong scale relative to arrows/text.
-
-4. **Renumber ids when merging fragments.** Two RDKit outputs both start ids at 1; collisions break reaction-step references. Assign a disjoint id block per fragment, then wire the `<step>` to the new ids.
-
-5. **Prefer CDXML (text) over CDX (binary).** CDXML is diff-able, editable, and reliably written. `rdChemDraw.MolToChemDrawBlock(..., CDX)` currently raises `UnicodeDecodeError`; only the legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` returns valid CDX bytes.
-
-6. **Verify write support at runtime.** Guard with `Chem.HasChemDrawCDXSupport()` — some conda builds ship without the ChemDraw parser and will raise on write.
-
-7. **Render heteroatom labels from `Element`, never as redundant free text.** A `<n Element="8">` node makes ChemDraw draw "O" automatically. Adding a separate `<t>O</t>` on top of it double-renders the label (a common auto-generation bug). Free `<t>` text is for captions, conditions, and compound names — not atom symbols.
-
-8. **Keep bond length uniform across every fragment.** A scheme where molecules are drawn at bond lengths of 30, 24, and 22 looks broken. RDKit emits a consistent scale per call, but merging fragments from mixed sources can drift — normalize them (`rdDepictor.NormalizeDepiction`) or rescale each fragment's coordinates to a common bond length before assembling. Vary size deliberately (e.g. enlarge a crowded cage), never accidentally.
-
-9. **A reaction scheme needs real arrow objects.** Structures floating on a page with no `<arrow>` (or `<graphic>` line) between them is not a scheme — it is a pile of molecules. Draw one arrow per step and place its conditions text above (arrow y − ~20) and below (arrow y + ~16) the arrow line.
-
-10. **Write a complete document header.** ChemDraw renders most reliably when the `<CDXML>` root carries `BondLength`, `LabelFont`/`LabelSize`, `CaptionFont`/`CaptionSize`, and the `<page>` has explicit `Width`/`Height`/`BoundingBox`, plus a standard `<colortable>`/`<fonttable>`. See `references/cdxml-schema-reference.md` for a copy-paste header.
-
-11. **XML-escape special characters in text.** `<`, `>`, and `&` inside a `<s>` run must be written as `&lt;`, `&gt;`, `&amp;` (e.g. a retrosynthesis note "3 -> 4" becomes "3 -&gt; 4"). `ElementTree` escapes automatically when you set `.text`; only hand-written strings need manual escaping.
-
-12. **Deliver the `.cdxml` and a rendered `.png` together, never the CDXML alone** (Module 9). CDXML is not viewable by eye, so the image is both the user's actual view and your own reliable check — rendering immediately exposes stray lines from a duplicate/degenerate arrow id, structures overlapping an arrow, condition text sitting on top of atoms, and a compressed scheme that dropped intermediates. Render the PNG next to the CDXML, run the lint recipe below (duplicate ids, repeated adjacent fragments, bond-length spread), fix what either surfaces, then hand over both files.
+1. **Compute 2D coordinates before writing** (`SetPreferCoordGen(True)` then `Compute2DCoords`); a molecule without coordinates writes as a degenerate layout.
+2. **Never round-trip a reaction through a Mol if you need the drawing** — reading drops arrows, plus signs, text, and graphics. Edit reaction files on the XML tree (Module 8).
+3. **Keep object ids globally unique.** Merging RDKit outputs (each starts at 1) collides and breaks `<step>` references and doubles arrows; renumber into disjoint blocks.
+4. **Prefer CDXML (text) over CDX (binary).** CDX write via `rdChemDraw` raises `UnicodeDecodeError`; only legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` returns valid CDX bytes.
+5. **Write a complete document header** — `<CDXML BondLength=...>` plus a standard `<fonttable>`/`<colortable>` and page dimensions. See `references/cdxml-schema-reference.md`.
+6. **Keep text ASCII** (font table is iso-8859-1); render heteroatoms via `<n Element=...>`, never as redundant free `<t>` text (which double-renders labels).
+7. **Deliver the CDXML and PNG together, and run `check_scheme.check_all` first.** The render and the critic catch overlaps, duplicate/degenerate arrows, dropped intermediates, and connectivity errors before the user sees them.
 
 ## Common Recipes
 
-### Recipe: Validate a hand-built CDXML by re-reading it
-
-When to use: confirm your assembled arrows/steps are semantically valid.
-
-```python
-from rdkit.Chem import rdChemReactions
-cdxml = open("esterification.cdxml", encoding="utf-8").read()
-rxns = rdChemReactions.ReactionsFromCDXMLBlock(cdxml, sanitize=True)
-assert rxns, "No reaction parsed — check ReactionStep* id references"
-print("OK:", rxns[0].GetNumReactantTemplates(), "reactants,",
-      rxns[0].GetNumProductTemplates(), "products")
-```
-
 ### Recipe: Batch SMILES → CDXML files
-
-When to use: generate a folder of ChemDraw figures for a compound list.
 
 ```python
 from rdkit import Chem
 from rdkit.Chem import rdChemDraw, rdDepictor
 from pathlib import Path
 
-rdDepictor.SetPreferCoordGen(True)
-Path("out").mkdir(exist_ok=True)
+rdDepictor.SetPreferCoordGen(True); Path("out").mkdir(exist_ok=True)
 for i, smi in enumerate(["CCO", "c1ccccc1", "CC(=O)O"]):
     m = Chem.MolFromSmiles(smi); rdDepictor.Compute2DCoords(m)
-    Path(f"out/mol_{i}.cdxml").write_text(
-        rdChemDraw.MolToChemDrawBlock(m, rdChemDraw.CDXFormat.CDXML), encoding="utf-8")
-print("Wrote", len(list(Path('out').glob('*.cdxml'))), "files")
+    Path(f"out/mol_{i}.cdxml").write_text(rdChemDraw.MolToChemDrawBlock(m), encoding="utf-8")
 ```
 
 ### Recipe: Pretty-print CDXML for inspection
 
-When to use: read the object tree while debugging assembly.
-
 ```python
 import xml.dom.minidom as minidom
-pretty = minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
-print(pretty.toprettyxml(indent="  ")[:1500])
-```
-
-### Recipe: Lint a generated scheme before rendering
-
-When to use: catch the common auto-generation defects (duplicate ids, an
-accidentally repeated structure, uneven scale) that render as stray lines,
-floating duplicates, or mismatched sizes.
-
-```python
-import xml.etree.ElementTree as ET
-from collections import Counter
-import statistics
-
-def lint_cdxml(path):
-    root = ET.fromstring(open(path, encoding="utf-8").read())
-    problems = []
-    # 1) duplicate ids (two <arrow id="120">, or a node id reused by a <t>)
-    ids = [e.get("id") for e in root.iter() if e.get("id")]
-    dups = [i for i, c in Counter(ids).items() if c > 1]
-    if dups:
-        problems.append(f"duplicate ids: {dups}")
-    # 2) bond-length spread across fragments (should be near-uniform)
-    def med_bond(fr):
-        pos = {n.get("id"): tuple(map(float, n.get("p").split()))
-               for n in fr.iter("n") if n.get("p")}
-        ds = [((pos[b.get('B')][0]-pos[b.get('E')][0])**2 +
-               (pos[b.get('B')][1]-pos[b.get('E')][1])**2)**0.5
-              for b in fr.iter("b") if b.get("B") in pos and b.get("E") in pos]
-        return statistics.median(ds) if ds else 0
-    bl = [round(med_bond(fr), 1) for fr in root.iter("fragment")]
-    # Flag only gross scale mismatches; deliberate emphasis (e.g. a larger
-    # cage) is fine, so use a loose threshold rather than demanding uniformity.
-    if bl and (max(bl) - min(bl)) > 0.35 * max(bl):
-        problems.append(f"gross bond-length mismatch across fragments: {bl}")
-    # 3) an <arrow> shorter than half a bond (degenerate)
-    for a in root.iter("arrow"):
-        if a.get("Head3D") and a.get("Tail3D"):
-            hx, hy, _ = map(float, a.get("Head3D").split())
-            tx, ty, _ = map(float, a.get("Tail3D").split())
-            if ((hx-tx)**2 + (hy-ty)**2)**0.5 < 15:
-                problems.append(f"degenerate arrow id={a.get('id')} (too short)")
-    return problems
-
-issues = lint_cdxml("scheme.cdxml")
-print("CLEAN" if not issues else "ISSUES:\n  " + "\n  ".join(issues))
+print(minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
+      .toprettyxml(indent="  ")[:1500])
 ```
 
 ## Troubleshooting
 
 | Problem | Cause | Solution |
 |---------|-------|----------|
-| `RuntimeError`/exception on `MolToChemDrawBlock` | RDKit built without ChemDraw support | Check `Chem.HasChemDrawCDXSupport()`; install a build with the Revvity parser (e.g. recent `pip install rdkit`) |
-| `UnicodeDecodeError` writing CDX | `rdChemDraw.MolToChemDrawBlock(..., CDX)` mis-decodes binary | Use legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` for CDX bytes, or write CDXML instead |
-| Structure written but flat/overlapping | No 2D coordinates computed | Call `rdDepictor.Compute2DCoords(mol)` before writing |
-| Edited reaction lost its arrows/text | File was round-tripped through `MolsFromChemDrawBlock` → `MolToChemDrawBlock` | Edit the XML tree directly (`ElementTree`); RDKit writes structures only |
-| Assembled reaction won't parse back as a reaction | `<step>` references ids that don't exist (id collision after merge) | Renumber all fragment ids to be globally unique, then update `ReactionStep*` attributes |
-| Structures and arrows rendered at mismatched sizes | `<CDXML BondLength="">` empty | Set a numeric `BondLength` (e.g. `"30"`) on the root element |
-| `mols` tuple empty on read | Wrong format assumed, or unsanitizable structure | Retry with `sanitize=False` to inspect; confirm the file is genuine CDX/CDXML |
-| Text shows wrong/no font | `<s font>` references a missing `<fonttable>` id | Include a `<fonttable>` with the referenced `font id`, or reuse the file's existing one |
-| Atom labels appear doubled/overlapping ("OO", "BrBr") | Redundant free-text `<t>` labels added on top of `Element` nodes | Remove the free `<t>` atom labels; let `<n Element="…">` render the symbol |
-| Molecules in a scheme are different sizes | Fragments assembled at different bond lengths | Rescale each fragment to one bond length (≈30) before assembling; `rdDepictor.NormalizeDepiction` per mol |
-| Structures present but no reaction shown | Scheme has no `<arrow>`/`<graphic>` line objects | Add an arrow per step; wire ids in `<step>` if RDKit must re-read it as a reaction |
-| Parser error on text with `<`, `>`, `&` | Unescaped special characters in a `<s>` run | Escape as `&lt;` `&gt;` `&amp;` (automatic when using `ElementTree` `.text`) |
-| Stray line crosses a structure in the render | Duplicate or degenerate `<arrow>` (e.g. two `<arrow id="120">`, one tiny) | Run the lint recipe; give every arrow a unique id and a real length (Head3D≠Tail3D) |
-| Condition text overlaps atoms/structures | Text placed on the structure instead of clear of the arrow | Put conditions above (arrow y − ~15) and below (arrow y + ~15); leave horizontal gaps between fragments |
-| Same structure appears twice / floating duplicate | A fragment was copied (e.g. a "from above" continuation) | Remove the duplicate fragment; lint recipe flags repeated adjacent SMILES |
-| `render*` options ignored / no image | Indigo renderer not installed, or CDXML loaded as molecule when it has arrows | `pip install epam.indigo`; try `loadReaction` first, fall back to `loadMolecule` |
+| Exception on `MolToChemDrawBlock` | RDKit built without ChemDraw support | Check `Chem.HasChemDrawCDXSupport()`; install a build with the Revvity parser |
+| `UnicodeDecodeError` writing CDX | `rdChemDraw` CDX path is broken | Use legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)`, or write CDXML |
+| Structure written flat/overlapping | No 2D coordinates | Call `rdDepictor.Compute2DCoords(mol)` before writing |
+| Edited reaction lost arrows/text | File round-tripped through a Mol | Edit the XML tree (`ElementTree`); RDKit writes structures only |
+| Reaction won't re-parse | `<step>` references missing ids (collision after merge) | Renumber fragment ids globally unique; update `ReactionStep*` |
+| Structures/arrows mismatched size | `<CDXML BondLength="">` empty | Set a numeric `BondLength` (e.g. `30`) on the root |
+| `mols` tuple empty on read | Wrong format, or unsanitizable structure | Retry with `sanitize=False`; confirm the file is genuine CDX/CDXML |
+| Doubled labels ("OO", "BrBr") | Free-text `<t>` on top of `Element` nodes | Remove the free labels; let `<n Element=...>` render the symbol |
+| Stray line crosses a structure | Duplicate or degenerate `<arrow>` | Run `check_scheme`; unique id + real length (`Head3D`≠`Tail3D`) per arrow |
+| Conditions text overlaps a structure | Text placed on the structure, not over the arrow gap | Center conditions over the arrow midpoint; widen structure spacing |
+| Text renders wrong/blank | non-ASCII, or `<s font>` id missing from `<fonttable>` | Keep text ASCII; reference an existing `font id` |
+| No PNG / render error | `epam.indigo` missing, or loaded as molecule when it has arrows | `pip install epam.indigo`; try `loadReaction` before `loadMolecule` |
 
 ## Bundled Resources
 
-- `references/cdxml-schema-reference.md` — element/attribute cheat-sheet for `n`, `b`, `arrow`, `graphic`, `step`/`scheme`, `t`/`s`, `fonttable`, `colortable`; coordinate conventions; and the `ArrowType`/`GraphicType`/`SymbolType`/font-face enumerations, distilled from the CambridgeSoft CDX/CDXML specification.
-- `scripts/build_reaction_scheme.py` — assemble a multi-step scheme from `(smiles, name, conditions)` steps and render the PNG in one call (Workflow 4). Handles grid layout, globally unique object ids, single arrows, and conditions text placed clear of structures — the defects that recur when schemes are hand-built. Runnable as a library (`build_scheme(...)`) or CLI (`python build_reaction_scheme.py steps.json out.cdxml out.png "Title"`).
+The `scripts/` files are read-only in the skill directory and are **not importable from there** — copy the ones you need into your working directory (read with `read_file`, write locally), then `import` or run them.
+
+- `references/cdxml-schema-reference.md` — element/attribute cheat-sheet (`n`, `b`, `arrow`, `graphic`, `step`/`scheme`, `t`/`s`, `fonttable`, `colortable`), coordinate conventions, enum tables, and a copy-paste document header.
+- `scripts/build_reaction_scheme.py` — assemble a multi-step scheme from `(smiles, name, conditions)` steps and render the PNG in one call; auto-sizes cells so structures never overlap. Library (`build_scheme(...)`) or CLI (`python build_reaction_scheme.py steps.json out.cdxml out.png "Title"`).
+- `scripts/check_scheme.py` — pre-delivery validator/critic. `check_all(path, expect=..., perspective_ids=...)` rebuilds each molecule from the drawing, sanitizes, prints formulas for a mass-balance check, and flags duplicate ids, overlaps, coincident/on-bond atoms, bond crossings, degenerate arrows, and non-ASCII text.
 
 ## Related Skills
 
-- **rdkit-cheminformatics** — descriptors, fingerprints, similarity, SMARTS; use for analysis once molecules are parsed from CDXML
+- **rdkit-cheminformatics** — descriptors, fingerprints, SMARTS; analysis once molecules are parsed
 - **datamol-cheminformatics** — higher-level RDKit wrapper for batch standardization before drawing
-- **openbabel** — multi-format 2D/3D conversion (MOL2, XYZ, PDB) when you need formats beyond ChemDraw
+- **openbabel** — multi-format 2D/3D conversion when you need formats beyond ChemDraw
 
 ## References
 
-- [RDKit `rdkit.Chem.rdChemDraw` documentation](https://www.rdkit.org/docs/source/rdkit.Chem.rdChemDraw.html) — `MolsFromChemDraw*`, `ReactionsFromChemDraw*`, `MolToChemDrawBlock`, `CDXFormat`
-- [RDKit `rdMolDraw2D` / depiction docs](https://www.rdkit.org/docs/source/rdkit.Chem.Draw.rdMolDraw2D.html) — 2D coordinate generation and CoordGen
-- [CDX/CDXML format specification (CambridgeSoft SDK mirror)](https://chemapps.stolaf.edu/iupac/cdx/sdk/) — object and property reference for arrows, graphics, reactions, and text
-- [RDKit CDXML test fixtures](https://github.com/rdkit/rdkit/tree/master/Code/GraphMol/test_data/CDXML) — real ChemDraw-authored `.cdxml` examples
-- [Indigo toolkit (`epam.indigo`)](https://lifescience.opensource.epam.com/indigo/) — CDX/CDXML loading and PNG/SVG rendering used in Module 9
+- [RDKit `rdkit.Chem.rdChemDraw`](https://www.rdkit.org/docs/source/rdkit.Chem.rdChemDraw.html) — `MolsFromChemDraw*`, `ReactionsFromChemDraw*`, `MolToChemDrawBlock`, `CDXFormat`
+- [RDKit depiction docs](https://www.rdkit.org/docs/source/rdkit.Chem.Draw.rdMolDraw2D.html) — 2D coordinates and CoordGen
+- [CDX/CDXML format specification (CambridgeSoft SDK mirror)](https://chemapps.stolaf.edu/iupac/cdx/sdk/) — arrows, graphics, reactions, text
+- [RDKit CDXML test fixtures](https://github.com/rdkit/rdkit/tree/master/Code/GraphMol/test_data/CDXML) — real ChemDraw-authored `.cdxml`
+- [Indigo toolkit (`epam.indigo`)](https://lifescience.opensource.epam.com/indigo/) — CDXML loading and PNG rendering

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -335,8 +335,10 @@ tree.write("output_reaction.cdxml", encoding="unicode", xml_declaration=True)
 The `scripts/` files can be **read** from the skill path but **not imported** from there — they are not on the execution sandbox's import path. Copy the two you need into your working directory first, then import. Each script depends only on rdkit (+ epam.indigo), never on the other, so copy them independently:
 
 ```python
-# 1) Copy the helpers into the workdir (read_file is routed to the skill backend):
-_SKILL = "SciAgent-Skills/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts"
+# 1) Copy the helpers into the workdir. Use the LEADING-SLASH skill path so the
+#    read routes to the skills backend (a path without the leading "/" is looked
+#    up in the sandbox workdir, where the file does not exist):
+_SKILL = "/SciAgent-Skills/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts"
 for name in ("build_reaction_scheme.py", "check_scheme.py"):
     open(name, "w").write(read_file(f"{_SKILL}/{name}"))   # read_file = your file tool
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -503,6 +503,20 @@ The helper renders as it builds, so **you can open the PNG, confirm the layout, 
 only then deliver both files** — the render step cannot be forgotten because it is
 part of the same call.
 
+Two things to know:
+
+- **Cells auto-size to the largest structure**, so big molecules (fused rings,
+  sulfonyl groups) never overlap their neighbours. This is the failure mode of
+  hand-placed coordinates — large structures collide because the spacing was
+  guessed. Let the helper compute spacing instead of hardcoding positions.
+- **Model convergent / multi-component steps by folding co-reactants into the
+  `conditions` text** (e.g. `conditions=["+ (MeO2C)2C=CHOMe", "Base, MeCN"]`),
+  keeping one main-chain structure per cell. The helper lays out a linear main
+  chain; drawing every co-reactant as a separate `+` structure is what pushes
+  people back to hand-building overlapping layouts. If a co-reactant must be
+  drawn, add it as its own step with an empty arrow, or place it with the raw
+  XML from Modules 5-7 after the main chain is built.
+
 ## Key Parameters
 
 | Parameter | Module / Function | Default | Range / Options | Effect |

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: "rdkit-chemdraw-cdxml"
+description: "Read, write, and edit ChemDraw CDX/CDXML files with RDKit's rdkit.Chem.rdChemDraw module plus direct XML editing. Parse molecules and reactions from .cdxml/.cdx, write clean molecule structures with good 2D depiction (CoordGen, template alignment), and hand-build or modify the parts RDKit cannot write: reaction arrows, plus signs, reaction schemes/steps, and free text/labels via the CDXML XML schema. Use when generating publication-ready chemical drawings, building reaction schemes programmatically, or modifying existing ChemDraw files. Critical: RDKit writes structures only; round-tripping a reaction through a Mol silently drops arrows and text — this skill shows the XML layer needed to preserve them. For pure molecular analysis (descriptors, fingerprints, SMARTS) use rdkit-cheminformatics; for multi-format 3D conversion use openbabel."
+license: "BSD-3-Clause"
+---
+
+# RDKit ChemDraw / CDXML Toolkit
+
+## Overview
+
+ChemDraw's native formats are CDX (binary) and CDXML (an XML serialization of the same object tree). RDKit 2022.09+ ships an optional Revvity ChemDraw parser exposed through `rdkit.Chem.rdChemDraw`, which reads molecules **and** reactions from both formats and writes molecule structures. This skill combines that RDKit I/O with direct CDXML XML editing, because RDKit writes only atoms/bonds/coordinates — reaction **arrows**, **plus signs**, **reaction schemes**, and free **text/labels** are ChemDraw canvas objects that must be built or edited at the XML level. The result is a full read → depict → annotate → write → modify workflow for programmatic ChemDraw drawings.
+
+## When to Use
+
+- Convert SMILES/SDF/Mol structures into `.cdxml` files that open cleanly in ChemDraw
+- Extract molecules or reactions (reactants/agents/products) from `.cdxml` or `.cdx` files
+- Build a reaction scheme programmatically: fragments + reaction arrow + `+` separators + conditions text
+- Add captions, atom labels, or annotations to a chemical drawing at specific canvas positions
+- Modify an existing ChemDraw file (relabel a group, add a note, reposition an arrow) without losing its arrows/text
+- Improve the 2D layout of a structure before export (CoordGen, template alignment, straightening)
+- Batch-generate ChemDraw figures for a reaction dataset or SAR table
+- Use `rdkit-cheminformatics` instead when you only need descriptors, fingerprints, similarity, or SMARTS — no ChemDraw I/O
+- For multi-format 3D structure conversion (MOL2, XYZ, PDB), use `openbabel` instead; this toolkit is 2D ChemDraw-specific
+
+## Prerequisites
+
+- **Python packages**: `rdkit` (2023.03+ recommended; must be built with ChemDraw support), `lxml` (optional, for pretty-printing/XPath); `xml.etree.ElementTree` from the stdlib is sufficient for editing
+- **Data requirements**: SMILES/Mol objects for writing; `.cdxml` (UTF-8 text) or `.cdx` (binary) files for reading
+- **Environment**: Python 3.9+; verify ChemDraw write support at runtime (see below) — some conda builds omit it
+
+> **Check before installing.** In a managed env (pixi/conda), RDKit is likely already present — run `python -c "import rdkit; print(rdkit.__version__)"` first and skip the install if it succeeds. Inside a pixi project, run scripts with `pixi run python ...`.
+
+```bash
+# Only if RDKit is not already available:
+pip install rdkit lxml
+# Then confirm the optional ChemDraw parser is compiled in:
+python -c "from rdkit import Chem; print('ChemDraw support:', Chem.HasChemDrawCDXSupport())"
+```
+
+## Quick Start
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdDepictor
+
+mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")  # aspirin
+rdDepictor.SetPreferCoordGen(True)                  # nicer layouts
+rdDepictor.Compute2DCoords(mol)                     # coordinates are REQUIRED before writing
+
+cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)  # -> str
+with open("aspirin.cdxml", "w", encoding="utf-8") as fh:
+    fh.write(cdxml)
+print(f"Wrote {len(cdxml)} chars of CDXML")
+```
+
+## Core API
+
+### Module 1: Reading molecules
+
+`MolsFromChemDrawFile` / `MolsFromChemDrawBlock` handle **both** `.cdx` and `.cdxml` and return a tuple of `Mol` objects (one per fragment on the page).
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw
+
+# From a file (.cdxml or .cdx — format auto-detected)
+mols = rdChemDraw.MolsFromChemDrawFile("drawing.cdxml", sanitize=True, removeHs=True)
+print(f"Parsed {len(mols)} molecule(s)")
+for m in mols:
+    print("  ", Chem.MolToSmiles(m))
+
+# From an in-memory block (str for CDXML, bytes for CDX)
+block = open("drawing.cdxml", encoding="utf-8").read()
+mols = rdChemDraw.MolsFromChemDrawBlock(block, sanitize=True, removeHs=True)
+
+# Legacy CDXML-only parser (no ChemDraw SDK needed) as a fallback:
+mols_legacy = Chem.MolsFromCDXML(block, sanitize=True, removeHs=True)
+```
+
+### Module 2: Reading reactions (arrows → reactant/product split)
+
+Arrows in ChemDraw carry the reaction semantics. `ReactionsFromChemDrawBlock` interprets `<step>`/`<arrow>` objects and returns `ChemicalReaction`s with reactants, agents, and products split out.
+
+```python
+from rdkit.Chem import rdChemDraw, rdChemReactions
+
+block = open("reaction.cdxml", encoding="utf-8").read()
+
+# Note: reaction reader defaults sanitize=False, removeHs=False
+rxns = rdChemDraw.ReactionsFromChemDrawBlock(block, sanitize=True, removeHs=False)
+for rxn in rxns:
+    print("reactants:", [Chem.MolToSmiles(m) for m in rxn.GetReactants()])
+    print("agents   :", [Chem.MolToSmiles(m) for m in rxn.GetAgents()])
+    print("products :", [Chem.MolToSmiles(m) for m in rxn.GetProducts()])
+
+# CDXML-only equivalent (legacy parser):
+rxns2 = rdChemReactions.ReactionsFromCDXMLBlock(block, sanitize=True, removeHs=False)
+```
+
+### Module 3: Writing molecule structures
+
+`MolToChemDrawBlock` writes one molecule. **CDXML returns `str`; CDX write is unreliable in `rdChemDraw`** (raises `UnicodeDecodeError`), so use the legacy writer for binary CDX bytes.
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdDepictor
+from rdkit.Chem import rdmolfiles
+
+mol = Chem.MolFromSmiles("c1ccccc1O")
+rdDepictor.Compute2DCoords(mol)                      # always compute coords first
+
+# CDXML (text) — preferred, works in both writers
+cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)   # str
+
+# CDX (binary) — use the LEGACY writer; rdChemDraw's CDX path is broken
+cdx_bytes = Chem.MolToCDXMLBlock(mol, rdmolfiles.CDXMLFormat.CDX)        # bytes
+with open("phenol.cdx", "wb") as fh:
+    fh.write(cdx_bytes)
+
+if not Chem.HasChemDrawCDXSupport():
+    raise RuntimeError("This RDKit build lacks ChemDraw write support")
+```
+
+### Module 4: Good molecular depiction (분자를 잘 그리기)
+
+Layout quality is set *before* you write. CoordGen gives more natural, less-overlapping 2D coordinates than the default algorithm; template alignment keeps a common scaffold oriented consistently across a series.
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdDepictor
+from rdkit.Chem import AllChem
+
+# 1) Prefer CoordGen globally for publication-like layouts
+rdDepictor.SetPreferCoordGen(True)
+
+mol = Chem.MolFromSmiles("O=C(Nc1ccc(cc1)S(=O)(=O)N)C")
+rdDepictor.Compute2DCoords(mol)
+
+# 2) Clean up: straighten rings/bonds and normalize bond length to a target
+rdDepictor.StraightenDepiction(mol)
+rdDepictor.NormalizeDepiction(mol)      # scales so the median bond length is uniform
+```
+
+```python
+# 3) Align a series to a shared scaffold so the core is drawn identically each time
+template = Chem.MolFromSmiles("c1ccc(cc1)S(=O)(=O)N")  # sulfonamide core
+rdDepictor.Compute2DCoords(template)
+
+series = [Chem.MolFromSmiles(s) for s in
+          ["Cc1ccc(cc1)S(=O)(=O)N", "Clc1ccc(cc1)S(=O)(=O)N"]]
+for m in series:
+    rdDepictor.GenerateDepictionMatching2DStructure(m, template)  # core aligned
+    print(Chem.MolToSmiles(m), "aligned to template")
+```
+
+### Module 5: Drawing arrows (화살표를 잘 그리기)
+
+RDKit cannot write arrows, so build them in CDXML. A reaction arrow is an `<arrow>` object with `Head3D`/`Tail3D` positions (`"x y z"`, y increases downward). The `ArrowheadHead`/`ArrowheadType` attributes control the head; `HeadSize` is in CDXML units (~1000/unit typical).
+
+```python
+import xml.etree.ElementTree as ET
+
+def make_arrow(arrow_id, tail_xy, head_xy, kind="Full"):
+    """Straight reaction arrow. kind: 'Full' (reaction), 'None' (line)."""
+    tx, ty = tail_xy
+    hx, hy = head_xy
+    arrow = ET.Element("arrow", {
+        "id": str(arrow_id),
+        "BoundingBox": f"{min(tx,hx)} {min(ty,hy)-4} {max(tx,hx)} {max(ty,hy)+4}",
+        "FillType": "None",
+        "ArrowheadType": "Solid",
+        "ArrowheadHead": kind,          # 'Full', 'HalfLeft', 'HalfRight', 'None'
+        "HeadSize": "2250",
+        "Head3D": f"{hx} {hy} 0",
+        "Tail3D": f"{tx} {ty} 0",
+    })
+    return arrow
+
+print(ET.tostring(make_arrow(40, (160, 100), (210, 100)), encoding="unicode"))
+# Equilibrium/resonance/retrosynthetic arrows: use a <graphic> Line with ArrowType
+equil = ET.Element("graphic", {"id": "41", "GraphicType": "Line",
+                               "ArrowType": "Equilibrium", "HeadSize": "2250",
+                               "BoundingBox": "160 100 210 100"})
+```
+
+### Module 6: Reaction schemes and steps
+
+A `<scheme>` groups one or more `<step>` objects. Each `<step>` references other objects **by id**: `ReactionStepReactants`, `ReactionStepProducts`, `ReactionStepArrows`, `ReactionStepPlusses`, and objects above/below the arrow (for conditions). Fragments and the arrow live on the `<page>`; the step just wires their ids together.
+
+```python
+import xml.etree.ElementTree as ET
+
+# Plus sign between two reactants (a Symbol graphic)
+def make_plus(gid, x, y):
+    return ET.Element("graphic", {"id": str(gid), "GraphicType": "Symbol",
+                                  "SymbolType": "Plus",
+                                  "BoundingBox": f"{x} {y-7} {x+15} {y+8}"})
+
+# Wire reactant/product/arrow ids into one reaction step
+step = ET.Element("step", {
+    "id": "61",
+    "ReactionStepReactants": "10 20",     # fragment ids, space-separated
+    "ReactionStepProducts": "50",
+    "ReactionStepArrows": "40",
+    "ReactionStepPlusses": "30",
+    "ReactionStepObjectsAboveArrow": "70",  # e.g. a text id for conditions
+})
+scheme = ET.Element("scheme", {"id": "60"})
+scheme.append(step)
+print(ET.tostring(scheme, encoding="unicode"))
+```
+
+### Module 7: Adding text and labels (텍스트를 잘 넣기)
+
+Free text is a `<t>` object positioned by `p="x y"`, containing one or more `<s>` styled-string children. Each `<s>` references a `font` id (from `<fonttable>`) and a `color` index (from `<colortable>`); `size` is in points and `face` is a style bitmask (1=bold, 2=italic, 4=underline; e.g. `96` = subscript/superscript flags used by ChemDraw).
+
+```python
+import xml.etree.ElementTree as ET
+
+def make_fonttable(font_id=21, name="Helvetica"):
+    ft = ET.Element("fonttable")
+    ET.SubElement(ft, "font", {"id": str(font_id), "charset": "x-mac-roman", "name": name})
+    return ft
+
+def make_colortable():
+    ct = ET.Element("colortable")
+    for r, g, b in [(1, 1, 1), (0, 0, 0)]:   # index 0=white(bg), then black...
+        ET.SubElement(ct, "color", {"r": str(r), "g": str(g), "b": str(b)})
+    return ct
+
+def make_text(tid, x, y, text, font_id=21, size=10, color=0, face=0):
+    t = ET.Element("t", {"id": str(tid), "p": f"{x} {y}"})
+    s = ET.SubElement(t, "s", {"font": str(font_id), "size": str(size),
+                               "color": str(color), "face": str(face)})
+    s.text = text
+    return t
+
+print(ET.tostring(make_text(70, 175, 92, "reflux, 2 h"), encoding="unicode"))
+```
+
+Chemical formulas need **subscripts/superscripts**, which ChemDraw renders by
+splitting a `<t>` into multiple `<s>` runs with different `face` bitmasks
+(`32`=subscript, `64`=superscript). One run per style change:
+
+```python
+import xml.etree.ElementTree as ET
+
+def make_formula(tid, x, y, runs, font_id=3, size=8.5):
+    """runs: list of (text, face). face 0=normal, 32=subscript, 64=superscript."""
+    t = ET.Element("t", {"id": str(tid), "p": f"{x} {y}"})
+    for text, face in runs:
+        s = ET.SubElement(t, "s", {"font": str(font_id), "size": str(size),
+                                   "color": "0", "face": str(face)})
+        s.text = text
+    return t
+
+# "Br2 (excess)"  ->  Br<sub>2</sub> (excess)
+print(ET.tostring(make_formula(80, 158, 135,
+      [("Br", 0), ("2", 32), (" (excess)", 0)]), encoding="unicode"))
+# "CO2H" -> CO<sub>2</sub>H
+print(ET.tostring(make_formula(81, 690, 730,
+      [("-CO", 0), ("2", 32), ("H", 0)]), encoding="unicode"))
+```
+
+### Module 8: Editing an existing CDXML file (수정)
+
+Because CDXML is generic XML, `ElementTree` round-trips arrows, text, and graphics it does not "understand" — so you can load a real ChemDraw file, tweak it, and save without losing objects. (RDKit's Mol round-trip would drop them.)
+
+```python
+import xml.etree.ElementTree as ET
+
+tree = ET.parse("reaction.cdxml")          # DOCTYPE is dropped on re-save (harmless)
+root = tree.getroot()
+page = root.find("page")
+
+# Relabel every "Cl" text object to "Br"
+for t in root.iter("t"):
+    for s in t.iter("s"):
+        if s.text == "Cl":
+            s.text = "Br"
+
+# Append a caption; reuse the file's existing font/color tables
+cap = ET.SubElement(page, "t", {"p": "100 300"})
+ET.SubElement(cap, "s", {"font": "21", "size": "12", "color": "0"}).text = "Scheme 1"
+
+tree.write("reaction_edited.cdxml", encoding="unicode", xml_declaration=True)
+print("Saved reaction_edited.cdxml")
+```
+
+## Key Concepts
+
+### CDXML coordinate system
+
+Positions use ChemDraw units where **y increases downward** (origin top-left). Atom positions are `p="x y"`; arrows use `Head3D`/`Tail3D="x y z"`; graphics and text carry a `BoundingBox="x1 y1 x2 y2"`. The default bond length is ~30 units. RDKit sometimes emits `<CDXML BondLength="">` (empty) — set a numeric `BondLength` (e.g. `"30"`) on the root when assembling files so ChemDraw scales sanely.
+
+```python
+# Shift a fragment's atoms by (dx, dy) to position it on the canvas
+def shift_fragment(frag, dx, dy):
+    for n in frag.iter("n"):
+        x, y = map(float, n.get("p").split())
+        n.set("p", f"{x+dx} {y+dy}")
+    return frag
+```
+
+### Object-id reference model
+
+Every object has a unique integer `id`. Reactions, groups, and brackets refer to their members **by id** rather than by nesting. When you merge fragments from separate RDKit outputs into one page, **renumber all ids to keep them globally unique**, then wire the reaction `<step>` to the new ids.
+
+### RDKit vs XML capability boundary
+
+| Task | RDKit `rdChemDraw` | Direct XML |
+|------|--------------------|-----------|
+| Read molecules | ✅ | — |
+| Read reactions (arrows) | ✅ | — |
+| Write molecule structure | ✅ (CDXML) | — |
+| Write arrows / plus / scheme | ❌ | ✅ |
+| Write text / captions | ❌ | ✅ |
+| Preserve objects while editing | ❌ (drops on Mol round-trip) | ✅ |
+
+## Common Workflows
+
+### Workflow 1: SMILES → cleanly depicted single-molecule CDXML
+
+**Goal**: Produce a ChemDraw file for one structure with a good 2D layout.
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdDepictor
+
+def smiles_to_cdxml(smiles, path):
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+    rdDepictor.SetPreferCoordGen(True)
+    rdDepictor.Compute2DCoords(mol)
+    rdDepictor.StraightenDepiction(mol)
+    cdxml = rdChemDraw.MolToChemDrawBlock(mol, rdChemDraw.CDXFormat.CDXML)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(cdxml)
+    return path
+
+print("Wrote", smiles_to_cdxml("CC(=O)Oc1ccccc1C(=O)O", "aspirin.cdxml"))
+```
+
+### Workflow 2: Build a full reaction scheme CDXML (arrow + plus + conditions)
+
+**Goal**: Assemble two reactants, a product, a reaction arrow, a `+` separator, and a text condition into one valid CDXML that ChemDraw opens and RDKit re-parses as a reaction.
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdDepictor, rdChemReactions
+import xml.etree.ElementTree as ET
+
+def _fragment_of(smiles, base_id, dx):
+    """Write one molecule to CDXML, extract its <fragment>, renumber ids, shift x."""
+    m = Chem.MolFromSmiles(smiles); rdDepictor.Compute2DCoords(m)
+    frag = ET.fromstring(rdChemDraw.MolToChemDrawBlock(m)).find("page/fragment")
+    remap = {}
+    for i, el in enumerate([frag, *frag.iter("n"), *frag.iter("b")]):
+        old = el.get("id"); remap[old] = str(base_id + i); el.set("id", remap[old])
+    for b in frag.iter("b"):                 # fix bond endpoint references
+        b.set("B", remap[b.get("B")]); b.set("E", remap[b.get("E")])
+    for n in frag.iter("n"):                 # shift onto the canvas
+        x, y = map(float, n.get("p").split()); n.set("p", f"{x+dx} {y}")
+    return frag
+
+root = ET.Element("CDXML", {"BondLength": "30"})
+page = ET.SubElement(root, "page")
+
+r1 = _fragment_of("CCO", 100, 0);      page.append(r1)      # reactant 1
+plus = ET.SubElement(page, "graphic", {"id": "30", "GraphicType": "Symbol",
+                                       "SymbolType": "Plus", "BoundingBox": "60 -7 75 8"})
+r2 = _fragment_of("CC(=O)O", 200, 120); page.append(r2)     # reactant 2
+arrow = ET.SubElement(page, "arrow", {"id": "40", "FillType": "None",
+        "ArrowheadHead": "Full", "ArrowheadType": "Solid", "HeadSize": "2250",
+        "BoundingBox": "260 0 320 7", "Head3D": "320 3 0", "Tail3D": "260 3 0"})
+cond = ET.SubElement(page, "t", {"id": "70", "p": "270 -12"})
+ET.SubElement(cond, "s", {"font": "21", "size": "9", "color": "0"}).text = "H+, reflux"
+prod = _fragment_of("CCOC(C)=O", 300, 360); page.append(prod)  # product
+
+scheme = ET.SubElement(page, "scheme", {"id": "60"})
+ET.SubElement(scheme, "step", {"id": "61", "ReactionStepReactants": "100 200",
+        "ReactionStepProducts": "300", "ReactionStepArrows": "40",
+        "ReactionStepPlusses": "30", "ReactionStepObjectsAboveArrow": "70"})
+ft = ET.SubElement(root, "fonttable")
+ET.SubElement(ft, "font", {"id": "21", "charset": "x-mac-roman", "name": "Helvetica"})
+
+cdxml = ET.tostring(root, encoding="unicode")
+open("esterification.cdxml", "w", encoding="utf-8").write(cdxml)
+
+# Verify: RDKit should re-parse it as a reaction
+rxns = rdChemReactions.ReactionsFromCDXMLBlock(cdxml, sanitize=True)
+print("Re-parsed reactions:", len(rxns))
+```
+
+### Workflow 3: Modify an existing ChemDraw file, preserving arrows and text
+
+**Goal**: Open a reaction someone drew, add an annotation and rescale, and save — without the arrow/text loss an RDKit Mol round-trip would cause.
+
+```python
+import xml.etree.ElementTree as ET
+
+tree = ET.parse("input_reaction.cdxml")
+root = tree.getroot()
+page = root.find("page")
+
+# Add a scheme title above the drawing
+title = ET.SubElement(page, "t", {"p": "50 -30"})
+ET.SubElement(title, "s", {"font": "21", "size": "14", "color": "0", "face": "1"}).text = "Route A"
+
+# Bump every arrow's head size so it reads at print scale
+for arrow in root.iter("arrow"):
+    arrow.set("HeadSize", "3000")
+
+tree.write("output_reaction.cdxml", encoding="unicode", xml_declaration=True)
+print("Edited file saved; arrows and existing text preserved")
+```
+
+## Key Parameters
+
+| Parameter | Module / Function | Default | Range / Options | Effect |
+|-----------|-------------------|---------|-----------------|--------|
+| `format` | `MolToChemDrawBlock` | `CDXFormat.CDXML` | `CDXML`, `CDX` | Output format; use CDXML (str). For CDX bytes use legacy `MolToCDXMLBlock` |
+| `sanitize` | `MolsFromChemDrawBlock` | `True` | `True`/`False` | Sanitize parsed mols; set `False` to inspect raw/invalid input |
+| `removeHs` | `MolsFromChemDrawBlock` | `True` | `True`/`False` | Convert explicit H to implicit |
+| `sanitize` | `ReactionsFromChemDrawBlock` | `False` | `True`/`False` | Reaction reader defaults **False** — pass `True` for clean SMILES |
+| CoordGen | `rdDepictor.SetPreferCoordGen` | `False` | `True`/`False` | `True` gives more natural 2D layouts |
+| `ArrowheadHead` | `<arrow>` XML | — | `Full`, `HalfLeft`, `HalfRight`, `None` | Arrowhead style on the reaction arrow |
+| `ArrowType` | `<graphic>` Line XML | — | `FullHead`, `Equilibrium`, `Resonance`, `RetroSynthetic`, `NoGo` | Special arrow semantics (equilibrium, retrosynthesis, failed) |
+| `BondLength` | `<CDXML>` root XML | `""` (RDKit) | numeric, e.g. `30` | Canvas scale; set explicitly to avoid ChemDraw scaling glitches |
+
+## Best Practices
+
+1. **Always compute 2D coordinates before writing.** `MolToChemDrawBlock` serializes existing conformer coordinates; without `Compute2DCoords` you get a degenerate layout.
+   ```python
+   rdDepictor.SetPreferCoordGen(True); rdDepictor.Compute2DCoords(mol)
+   ```
+
+2. **Never round-trip a reaction through an RDKit `Mol`/`ChemicalReaction` if you need to keep the drawing.** Reading loses arrows, plus signs, text, and graphics. To *edit* a reaction file, work on the XML tree (Module 8), not on parsed objects.
+
+3. **Set a numeric `BondLength` on the CDXML root when assembling files by hand.** RDKit emits `BondLength=""`, which can make ChemDraw render structures at the wrong scale relative to arrows/text.
+
+4. **Renumber ids when merging fragments.** Two RDKit outputs both start ids at 1; collisions break reaction-step references. Assign a disjoint id block per fragment, then wire the `<step>` to the new ids.
+
+5. **Prefer CDXML (text) over CDX (binary).** CDXML is diff-able, editable, and reliably written. `rdChemDraw.MolToChemDrawBlock(..., CDX)` currently raises `UnicodeDecodeError`; only the legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` returns valid CDX bytes.
+
+6. **Verify write support at runtime.** Guard with `Chem.HasChemDrawCDXSupport()` — some conda builds ship without the ChemDraw parser and will raise on write.
+
+7. **Render heteroatom labels from `Element`, never as redundant free text.** A `<n Element="8">` node makes ChemDraw draw "O" automatically. Adding a separate `<t>O</t>` on top of it double-renders the label (a common auto-generation bug). Free `<t>` text is for captions, conditions, and compound names — not atom symbols.
+
+8. **Keep bond length uniform across every fragment.** A scheme where molecules are drawn at bond lengths of 30, 24, and 22 looks broken. RDKit emits a consistent scale per call, but merging fragments from mixed sources can drift — normalize them (`rdDepictor.NormalizeDepiction`) or rescale each fragment's coordinates to a common bond length before assembling. Vary size deliberately (e.g. enlarge a crowded cage), never accidentally.
+
+9. **A reaction scheme needs real arrow objects.** Structures floating on a page with no `<arrow>` (or `<graphic>` line) between them is not a scheme — it is a pile of molecules. Draw one arrow per step and place its conditions text above (arrow y − ~20) and below (arrow y + ~16) the arrow line.
+
+10. **Write a complete document header.** ChemDraw renders most reliably when the `<CDXML>` root carries `BondLength`, `LabelFont`/`LabelSize`, `CaptionFont`/`CaptionSize`, and the `<page>` has explicit `Width`/`Height`/`BoundingBox`, plus a standard `<colortable>`/`<fonttable>`. See `references/cdxml-schema-reference.md` for a copy-paste header.
+
+11. **XML-escape special characters in text.** `<`, `>`, and `&` inside a `<s>` run must be written as `&lt;`, `&gt;`, `&amp;` (e.g. a retrosynthesis note "3 -> 4" becomes "3 -&gt; 4"). `ElementTree` escapes automatically when you set `.text`; only hand-written strings need manual escaping.
+
+## Common Recipes
+
+### Recipe: Validate a hand-built CDXML by re-reading it
+
+When to use: confirm your assembled arrows/steps are semantically valid.
+
+```python
+from rdkit.Chem import rdChemReactions
+cdxml = open("esterification.cdxml", encoding="utf-8").read()
+rxns = rdChemReactions.ReactionsFromCDXMLBlock(cdxml, sanitize=True)
+assert rxns, "No reaction parsed — check ReactionStep* id references"
+print("OK:", rxns[0].GetNumReactantTemplates(), "reactants,",
+      rxns[0].GetNumProductTemplates(), "products")
+```
+
+### Recipe: Batch SMILES → CDXML files
+
+When to use: generate a folder of ChemDraw figures for a compound list.
+
+```python
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdDepictor
+from pathlib import Path
+
+rdDepictor.SetPreferCoordGen(True)
+Path("out").mkdir(exist_ok=True)
+for i, smi in enumerate(["CCO", "c1ccccc1", "CC(=O)O"]):
+    m = Chem.MolFromSmiles(smi); rdDepictor.Compute2DCoords(m)
+    Path(f"out/mol_{i}.cdxml").write_text(
+        rdChemDraw.MolToChemDrawBlock(m, rdChemDraw.CDXFormat.CDXML), encoding="utf-8")
+print("Wrote", len(list(Path('out').glob('*.cdxml'))), "files")
+```
+
+### Recipe: Pretty-print CDXML for inspection
+
+When to use: read the object tree while debugging assembly.
+
+```python
+import xml.dom.minidom as minidom
+pretty = minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
+print(pretty.toprettyxml(indent="  ")[:1500])
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `RuntimeError`/exception on `MolToChemDrawBlock` | RDKit built without ChemDraw support | Check `Chem.HasChemDrawCDXSupport()`; install a build with the Revvity parser (e.g. recent `pip install rdkit`) |
+| `UnicodeDecodeError` writing CDX | `rdChemDraw.MolToChemDrawBlock(..., CDX)` mis-decodes binary | Use legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` for CDX bytes, or write CDXML instead |
+| Structure written but flat/overlapping | No 2D coordinates computed | Call `rdDepictor.Compute2DCoords(mol)` before writing |
+| Edited reaction lost its arrows/text | File was round-tripped through `MolsFromChemDrawBlock` → `MolToChemDrawBlock` | Edit the XML tree directly (`ElementTree`); RDKit writes structures only |
+| Assembled reaction won't parse back as a reaction | `<step>` references ids that don't exist (id collision after merge) | Renumber all fragment ids to be globally unique, then update `ReactionStep*` attributes |
+| Structures and arrows rendered at mismatched sizes | `<CDXML BondLength="">` empty | Set a numeric `BondLength` (e.g. `"30"`) on the root element |
+| `mols` tuple empty on read | Wrong format assumed, or unsanitizable structure | Retry with `sanitize=False` to inspect; confirm the file is genuine CDX/CDXML |
+| Text shows wrong/no font | `<s font>` references a missing `<fonttable>` id | Include a `<fonttable>` with the referenced `font id`, or reuse the file's existing one |
+| Atom labels appear doubled/overlapping ("OO", "BrBr") | Redundant free-text `<t>` labels added on top of `Element` nodes | Remove the free `<t>` atom labels; let `<n Element="…">` render the symbol |
+| Molecules in a scheme are different sizes | Fragments assembled at different bond lengths | Rescale each fragment to one bond length (≈30) before assembling; `rdDepictor.NormalizeDepiction` per mol |
+| Structures present but no reaction shown | Scheme has no `<arrow>`/`<graphic>` line objects | Add an arrow per step; wire ids in `<step>` if RDKit must re-read it as a reaction |
+| Parser error on text with `<`, `>`, `&` | Unescaped special characters in a `<s>` run | Escape as `&lt;` `&gt;` `&amp;` (automatic when using `ElementTree` `.text`) |
+
+## Bundled Resources
+
+- `references/cdxml-schema-reference.md` — element/attribute cheat-sheet for `n`, `b`, `arrow`, `graphic`, `step`/`scheme`, `t`/`s`, `fonttable`, `colortable`; coordinate conventions; and the `ArrowType`/`GraphicType`/`SymbolType`/font-face enumerations, distilled from the CambridgeSoft CDX/CDXML specification.
+
+## Related Skills
+
+- **rdkit-cheminformatics** — descriptors, fingerprints, similarity, SMARTS; use for analysis once molecules are parsed from CDXML
+- **datamol-cheminformatics** — higher-level RDKit wrapper for batch standardization before drawing
+- **openbabel** — multi-format 2D/3D conversion (MOL2, XYZ, PDB) when you need formats beyond ChemDraw
+
+## References
+
+- [RDKit `rdkit.Chem.rdChemDraw` documentation](https://www.rdkit.org/docs/source/rdkit.Chem.rdChemDraw.html) — `MolsFromChemDraw*`, `ReactionsFromChemDraw*`, `MolToChemDrawBlock`, `CDXFormat`
+- [RDKit `rdMolDraw2D` / depiction docs](https://www.rdkit.org/docs/source/rdkit.Chem.Draw.rdMolDraw2D.html) — 2D coordinate generation and CoordGen
+- [CDX/CDXML format specification (CambridgeSoft SDK mirror)](https://chemapps.stolaf.edu/iupac/cdx/sdk/) — object and property reference for arrows, graphics, reactions, and text
+- [RDKit CDXML test fixtures](https://github.com/rdkit/rdkit/tree/master/Code/GraphMol/test_data/CDXML) — real ChemDraw-authored `.cdxml` examples

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -378,7 +378,7 @@ print(f"Deliverables: {cdxml} + {png}")
 3. **Keep object ids globally unique.** Merging RDKit outputs (each starts at 1) collides and breaks `<step>` references and doubles arrows; renumber into disjoint blocks.
 4. **Prefer CDXML (text) over CDX (binary).** CDX write via `rdChemDraw` raises `UnicodeDecodeError`; only legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` returns valid CDX bytes.
 5. **Write a complete document header** — `<CDXML BondLength=...>` plus a standard `<fonttable>`/`<colortable>` and page dimensions. See `references/cdxml-schema-reference.md`.
-6. **Keep text ASCII** (font table is iso-8859-1); render heteroatoms via `<n Element=...>`, never as redundant free `<t>` text (which double-renders labels).
+6. **Keep text ASCII** (font table is iso-8859-1); render heteroatoms via `<n Element=...>`, never as redundant free `<t>` text. Do **not** add decorative flag words like "Chiral"/"racemic" — show stereochemistry with wedge bonds. Keep every label clear of the arrow line: compound names go under their structure, conditions go offset above/beside the arrow, never on it.
 7. **Deliver the CDXML and PNG together, and run `check_scheme.check_all` first.** The render and the critic catch overlaps, duplicate/degenerate arrows, dropped intermediates, and connectivity errors before the user sees them.
 
 ## Common Recipes
@@ -420,6 +420,9 @@ print(minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
 | Conditions text overlaps a structure | Text placed on the structure, not over the arrow gap | Center conditions over the arrow midpoint; widen structure spacing |
 | Text renders wrong/blank | non-ASCII, or `<s font>` id missing from `<fonttable>` | Keep text ASCII; reference an existing `font id` |
 | No PNG / render error | `epam.indigo` missing, or loaded as molecule when it has arrows | `pip install epam.indigo`; try `loadReaction` before `loadMolecule` |
+| "Chiral"/"racemic" printed above structures | Decorative flag text added as `<t>` | Remove it — stereochemistry is shown by wedge bonds; `check_scheme` flags it |
+| A name or label sits on an arrow | Text placed on the arrow line | Names go under the structure, conditions offset above/beside the arrow; `check_scheme` flags text on an arrow |
+| `stoi: no conversion` loading in Indigo | `<CDXML BondLength="">` empty | Set a numeric `BondLength` (e.g. `30`) before rendering |
 
 ## Bundled Resources
 
@@ -427,7 +430,7 @@ The `scripts/` files can be read from the skill path but **not imported from the
 
 - `references/cdxml-schema-reference.md` — element/attribute cheat-sheet (`n`, `b`, `arrow`, `graphic`, `step`/`scheme`, `t`/`s`, `fonttable`, `colortable`), coordinate conventions, enum tables, and a copy-paste document header.
 - `scripts/build_reaction_scheme.py` — assemble a multi-step scheme from `(smiles, name, conditions)` steps and render the PNG in one call; auto-sizes cells so structures never overlap. Library (`build_scheme(...)`) or CLI (`python build_reaction_scheme.py steps.json out.cdxml out.png "Title"`).
-- `scripts/check_scheme.py` — pre-delivery validator/critic. `check_all(path, expect=..., perspective_ids=...)` rebuilds each molecule from the drawing, sanitizes, prints formulas for a mass-balance check, and flags duplicate ids, overlaps, coincident/on-bond atoms, bond crossings, degenerate arrows, and non-ASCII text.
+- `scripts/check_scheme.py` — pre-delivery validator/critic. `check_all(path, expect=..., perspective_ids=...)` rebuilds each molecule from the drawing, sanitizes, prints formulas for a mass-balance check, and flags duplicate ids, fragment overlaps, degenerate arrows, non-ASCII text, decorative flag words ("Chiral"), and labels sitting on an arrow line.
 
 ## Related Skills
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -121,7 +121,7 @@ if not Chem.HasChemDrawCDXSupport():
     raise RuntimeError("This RDKit build lacks ChemDraw write support")
 ```
 
-### Module 4: Good molecular depiction (분자를 잘 그리기)
+### Module 4: Good molecular depiction
 
 Layout quality is set *before* you write. CoordGen gives more natural, less-overlapping 2D coordinates than the default algorithm; template alignment keeps a common scaffold oriented consistently across a series.
 
@@ -153,7 +153,7 @@ for m in series:
     print(Chem.MolToSmiles(m), "aligned to template")
 ```
 
-### Module 5: Drawing arrows (화살표를 잘 그리기)
+### Module 5: Drawing arrows
 
 RDKit cannot write arrows, so build them in CDXML. A reaction arrow is an `<arrow>` object with `Head3D`/`Tail3D` positions (`"x y z"`, y increases downward). The `ArrowheadHead`/`ArrowheadType` attributes control the head; `HeadSize` is in CDXML units (~1000/unit typical).
 
@@ -210,7 +210,7 @@ scheme.append(step)
 print(ET.tostring(scheme, encoding="unicode"))
 ```
 
-### Module 7: Adding text and labels (텍스트를 잘 넣기)
+### Module 7: Adding text and labels
 
 Free text is a `<t>` object positioned by `p="x y"`, containing one or more `<s>` styled-string children. Each `<s>` references a `font` id (from `<fonttable>`) and a `color` index (from `<colortable>`); `size` is in points and `face` is a style bitmask (1=bold, 2=italic, 4=underline; e.g. `96` = subscript/superscript flags used by ChemDraw).
 
@@ -262,7 +262,7 @@ print(ET.tostring(make_formula(81, 690, 730,
       [("-CO", 0), ("2", 32), ("H", 0)]), encoding="unicode"))
 ```
 
-### Module 8: Editing an existing CDXML file (수정)
+### Module 8: Editing an existing CDXML file
 
 Because CDXML is generic XML, `ElementTree` round-trips arrows, text, and graphics it does not "understand" — so you can load a real ChemDraw file, tweak it, and save without losing objects. (RDKit's Mol round-trip would drop them.)
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -288,11 +288,14 @@ tree.write("reaction_edited.cdxml", encoding="unicode", xml_declaration=True)
 print("Saved reaction_edited.cdxml")
 ```
 
-### Module 9: Rendering CDXML to PNG (visual QA)
+### Module 9: Rendering CDXML to PNG (paired deliverable + visual QA)
 
-CDXML is not human-viewable on its own. **Always render what you generate and look
-at it** — rendering is the fastest way to catch overlapping structures, stray
-arrows (from duplicate/degenerate arrow ids), and text colliding with atoms.
+CDXML is not human-viewable on its own, so **a `.cdxml` should never be handed
+over alone — always deliver it together with a rendered `.png` (or `.svg`) of the
+same drawing.** The image serves two purposes: it is what the user actually looks
+at, and it is your own fastest check for overlapping structures, stray arrows
+(from duplicate/degenerate arrow ids), and text colliding with atoms. Render the
+PNG next to the CDXML (same basename), verify it visually, then provide both files.
 [Indigo](https://lifescience.opensource.epam.com/indigo/) (`epam.indigo`, renderer
 bundled) loads a CDXML — a scheme with arrows as a *reaction*, a lone structure as
 a *molecule* — and rasterizes arrows, text, and layout faithfully.
@@ -315,7 +318,12 @@ def render_cdxml(cdxml_path, png_path, width=1600):
     rnd.renderToFile(obj, png_path)
     return png_path
 
-print("Wrote", render_cdxml("scheme.cdxml", "scheme.png"))
+# Render the PNG as a sibling of the CDXML, then deliver BOTH files together
+from pathlib import Path
+src = "scheme.cdxml"
+png = str(Path(src).with_suffix(".png"))
+render_cdxml(src, png)
+print(f"Deliverables: {src} + {png}")
 ```
 
 RDKit can also draw a *parsed* reaction (`Draw.ReactionToImage(rxn)`), but it
@@ -411,7 +419,7 @@ arrow = ET.SubElement(page, "arrow", {"id": "40", "FillType": "None",
         "BoundingBox": "260 0 320 7", "Head3D": "320 3 0", "Tail3D": "260 3 0"})
 cond = ET.SubElement(page, "t", {"id": "70", "p": "270 -12"})
 ET.SubElement(cond, "s", {"font": "21", "size": "9", "color": "0"}).text = "H+, reflux"
-prod = _fragment_of("CCOC(C)=O", 300, 360); page.append(prod)  # product
+prod = _fragment_of("CCOC(C)=O", 300, 420); page.append(prod)  # product (clear of arrow)
 
 scheme = ET.SubElement(page, "scheme", {"id": "60"})
 ET.SubElement(scheme, "step", {"id": "61", "ReactionStepReactants": "100 200",
@@ -426,6 +434,14 @@ open("esterification.cdxml", "w", encoding="utf-8").write(cdxml)
 # Verify: RDKit should re-parse it as a reaction
 rxns = rdChemReactions.ReactionsFromCDXMLBlock(cdxml, sanitize=True)
 print("Re-parsed reactions:", len(rxns))
+
+# Deliverable pair: render a PNG next to the CDXML (see Module 9) and hand over both
+from indigo import Indigo
+from indigo.renderer import IndigoRenderer
+ind = Indigo(); rnd = IndigoRenderer(ind)
+ind.setOption("render-output-format", "png"); ind.setOption("render-image-width", 1600)
+rnd.renderToFile(ind.loadReaction(cdxml), "esterification.png")
+print("Deliverables: esterification.cdxml + esterification.png")
 ```
 
 ### Workflow 3: Modify an existing ChemDraw file, preserving arrows and text
@@ -491,7 +507,7 @@ print("Edited file saved; arrows and existing text preserved")
 
 11. **XML-escape special characters in text.** `<`, `>`, and `&` inside a `<s>` run must be written as `&lt;`, `&gt;`, `&amp;` (e.g. a retrosynthesis note "3 -> 4" becomes "3 -&gt; 4"). `ElementTree` escapes automatically when you set `.text`; only hand-written strings need manual escaping.
 
-12. **Render and look at every file you generate** (Module 9). CDXML is not viewable by eye; the only reliable check is to rasterize it. Rendering immediately exposes stray lines from a duplicate/degenerate arrow id, structures overlapping an arrow, condition text sitting on top of atoms, and a compressed scheme that dropped intermediates. Pair it with the validation recipe below (duplicate ids, repeated adjacent fragments, bond-length spread) so both the XML and the picture are checked before you hand the file over.
+12. **Deliver the `.cdxml` and a rendered `.png` together, never the CDXML alone** (Module 9). CDXML is not viewable by eye, so the image is both the user's actual view and your own reliable check — rendering immediately exposes stray lines from a duplicate/degenerate arrow id, structures overlapping an arrow, condition text sitting on top of atoms, and a compressed scheme that dropped intermediates. Render the PNG next to the CDXML, run the lint recipe below (duplicate ids, repeated adjacent fragments, bond-length spread), fix what either surfaces, then hand over both files.
 
 ## Common Recipes
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/references/cdxml-schema-reference.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/references/cdxml-schema-reference.md
@@ -1,0 +1,217 @@
+# CDXML Schema Reference (ChemDraw)
+
+Distilled from the CambridgeSoft/Revvity CDX/CDXML SDK specification
+(<https://chemapps.stolaf.edu/iupac/cdx/sdk/>) and cross-checked against real
+ChemDraw-authored files in the RDKit test corpus. CDXML is plain XML with **no
+namespace** and **case-sensitive** element names, so `xml.etree.ElementTree`
+handles it directly.
+
+## Document skeleton
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<CDXML BondLength="30">
+  <colortable>
+    <color r="1" g="1" b="1"/>   <!-- index 0 -->
+    <color r="0" g="0" b="0"/>   <!-- index 1 (indices count from the SECOND color in some readers) -->
+  </colortable>
+  <fonttable>
+    <font id="21" charset="x-mac-roman" name="Helvetica"/>
+  </fonttable>
+  <page>
+    <fragment>…</fragment>       <!-- molecules -->
+    <graphic/> <arrow/> <t>…</t> <!-- plus signs, arrows, text -->
+    <scheme><step .../></scheme> <!-- reaction wiring -->
+  </page>
+</CDXML>
+```
+
+- `id` is a unique integer on (almost) every object; other objects reference it.
+- Coordinates: **y increases downward**, origin top-left. Default `BondLength` ≈ 30.
+- Positions: `p="x y"`. Bounding boxes: `BoundingBox="x1 y1 x2 y2"`.
+
+## Recommended document header (copy-paste)
+
+RDKit writes a minimal `<CDXML BondLength="">` root. Files that render cleanly and
+consistently in ChemDraw carry a fuller header, standard color table, and page
+dimensions. Use this template when assembling a document by hand:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE CDXML SYSTEM "http://www.cambridgesoft.com/xml/cdxml.dtd" >
+<CDXML CreationProgram="my-generator" BondLength="30"
+       LabelFont="3" LabelSize="10" CaptionFont="3" CaptionSize="10"
+       HashSpacing="2.50" MarginWidth="1.60" LineWidth="0.60" BoldWidth="2"
+       BondSpacing="12" ChainAngle="120" color="0" bgcolor="1">
+  <colortable>                 <!-- standard 8-color ChemDraw table -->
+    <color r="1" g="1" b="1"/> <!-- 0 white / background -->
+    <color r="0" g="0" b="0"/> <!-- 1 black -->
+    <color r="1" g="0" b="0"/> <!-- 2 red -->
+    <color r="1" g="1" b="0"/> <!-- 3 yellow -->
+    <color r="0" g="1" b="0"/> <!-- 4 green -->
+    <color r="0" g="1" b="1"/> <!-- 5 cyan -->
+    <color r="0" g="0" b="1"/> <!-- 6 blue -->
+    <color r="1" g="0" b="1"/> <!-- 7 magenta -->
+  </colortable>
+  <fonttable>
+    <font id="3" charset="iso-8859-1" name="Arial"/>
+    <font id="4" charset="iso-8859-1" name="Times New Roman"/>
+  </fonttable>
+  <page id="99" HeightPages="1" WidthPages="1" Width="940" Height="940"
+        BoundingBox="0 0 940 940" DrawingSpace="poster">
+    <!-- fragments, arrows, text, scheme go here -->
+  </page>
+</CDXML>
+```
+
+Size the `<page>` `Width`/`Height`/`BoundingBox` to the actual extent of the
+drawing (a multi-step scheme needs a large "poster" space); a page smaller than
+the content clips it in ChemDraw.
+
+## Molecule objects
+
+| Element | Meaning | Key attributes |
+|---------|---------|----------------|
+| `fragment` | one connected molecule | `id` |
+| `n` | node (atom) | `id`, `p="x y"`, `Element` (atomic number; omitted → carbon), `Charge`, `NumHydrogens`, `NodeType` |
+| `b` | bond | `id`, `B` (begin node id), `E` (end node id), `Order` (omitted → 1; `2`, `3`, `1.5`), `Display` (`WedgeBegin`, `WedgeEnd`, `Hash`, …) |
+
+```xml
+<fragment id="3">
+  <n id="4" p="-76.7 -9.0"/>              <!-- carbon -->
+  <n id="6" p="-51.9 34.2" Element="8"/>  <!-- oxygen -->
+  <b id="18" B="5" E="6" Order="2"/>      <!-- C=O -->
+</fragment>
+```
+
+## Arrow objects
+
+Two representations exist; ChemDraw writes both (the `<graphic>` line is often
+`SupersededBy` the modern `<arrow>`). A reaction `<step>` may reference **either** id.
+
+### Modern `<arrow>`
+
+```xml
+<arrow id="396" BoundingBox="329.6 236.3 389.8 248.5"
+       FillType="None" ArrowheadHead="Full" ArrowheadType="Solid"
+       HeadSize="2250" ArrowheadCenterSize="1969" ArrowheadWidth="563"
+       Head3D="389.8 242.9 0" Tail3D="329.6 242.9 0"/>
+```
+
+| Attribute | Meaning |
+|-----------|---------|
+| `Tail3D`, `Head3D` | start/end points `"x y z"` (z usually 0) |
+| `ArrowheadHead` | `Full`, `HalfLeft`, `HalfRight`, `None` |
+| `ArrowheadType` | `Solid`, `Hollow`, `Angle` |
+| `HeadSize`, `ArrowheadWidth` | arrowhead geometry (CDXML units ×100) |
+| `FillType` | `None`, `Solid` |
+
+### Legacy `<graphic>` line-arrow
+
+```xml
+<graphic id="327" GraphicType="Line" ArrowType="FullHead"
+         HeadSize="2250" BoundingBox="389.8 242.9 329.6 242.9"/>
+```
+
+`ArrowType` enumeration (bit-combinable): `NoHead`(0), `HalfHead`(1),
+`FullHead`(2), `Resonance`(4), `Equilibrium`(8), `Hollow`(16),
+`RetroSynthetic`(32), `NoGo`(64, crossed-out/failed), `Dipole`(128).
+
+## Graphic objects (non-arrow)
+
+`GraphicType` enumeration: `Undefined`(0), `Line`(1), `Arc`(2), `Rectangle`(3),
+`Oval`(4), `Orbital`(5), `Bracket`(6), `Symbol`(7).
+
+For graphics, `BoundingBox` is a **pair of points**, not a rectangle — its
+meaning depends on the type (e.g. Line = start+end; Arc = center+end).
+
+### Reaction plus sign (`Symbol`)
+
+```xml
+<graphic id="318" GraphicType="Symbol" SymbolType="Plus"
+         BoundingBox="178.4 242.9 178.4 250.4"/>
+```
+
+`SymbolType` values include `Plus`, `Minus`, `LonePair`, `Dagger`, `Charge*`.
+
+## Reaction wiring: `<scheme>` and `<step>`
+
+A `<scheme>` (CDXML name `scheme`) contains one or more `<step>` objects. The
+step holds no geometry — it references page objects by id.
+
+```xml
+<scheme id="397">
+  <step id="398"
+        ReactionStepReactants="303 320"
+        ReactionStepProducts="369"
+        ReactionStepArrows="327"
+        ReactionStepPlusses="318"
+        ReactionStepObjectsAboveArrow="410"
+        ReactionStepObjectsBelowArrow="411"
+        ReactionStepAtomMap="306 348 300 354"/>   <!-- reactant→product atom id pairs -->
+</scheme>
+```
+
+| Attribute | Contents (space-separated object-id list) |
+|-----------|-------------------------------------------|
+| `ReactionStepReactants` | reactant fragment ids, in order |
+| `ReactionStepProducts` | product fragment ids |
+| `ReactionStepArrows` | arrow/graphic-line ids |
+| `ReactionStepPlusses` | plus-symbol graphic ids |
+| `ReactionStepObjectsAboveArrow` / `…BelowArrow` | ids of text/fragments as conditions |
+| `ReactionStepAtomMap` | flat list of mapped atom-id pairs |
+
+## Text objects: `<t>` and `<s>`
+
+A `<t>` block is positioned by `p`; it holds one or more `<s>` (style) runs, each
+a single style. `<s>` references a `font` id and `color` index; `size` is in
+points; `face` is a style bitmask.
+
+```xml
+<t p="137.4 218.1" BoundingBox="137.8 210.8 146.1 218.3"
+   LabelJustification="Left" Justification="Left">
+  <s font="21" size="10" color="0" face="96">Cl</s>
+</t>
+```
+
+| `<t>` attribute | Meaning |
+|-----------------|---------|
+| `p` | anchor position `"x y"` |
+| `BoundingBox` | enclosing rectangle |
+| `Justification` | text alignment (`Left`, `Center`, `Right`) |
+| `LabelJustification` | alignment when used as an atom label |
+
+`<s>` **face** bitmask: `1`=Bold, `2`=Italic, `4`=Underline, `8`=Outline,
+`16`=Shadow, `32`=Subscript, `64`=Superscript (ChemDraw combines these; the
+value `96` = subscript+superscript flags seen on formula labels). `color`
+indexes the `<colortable>`; `font` matches a `<font id>` in `<fonttable>`.
+
+## fonttable / colortable
+
+```xml
+<fonttable>
+  <font id="21" charset="x-mac-roman" name="Helvetica"/>
+</fonttable>
+<colortable>
+  <color r="1" g="1" b="1"/>   <!-- r,g,b in 0..1 -->
+  <color r="0" g="0" b="0"/>
+</colortable>
+```
+
+Any `<s font="…">` and `<s color="…">` must reference ids/indices that exist in
+these tables, or ChemDraw falls back to defaults. When editing an existing file,
+reuse its tables rather than adding duplicates.
+
+## Practical assembly rules
+
+1. **Globally unique ids.** Merging fragments from separate RDKit outputs (each
+   starting ids at 1) collides — renumber into disjoint blocks first, and fix
+   every `b B/E` and `ReactionStep*` reference to match.
+2. **Set `BondLength`.** RDKit writes `BondLength=""`; put a number (≈30) so
+   arrows/text scale consistently with structures.
+3. **Position with real coordinates.** Fragments carry their own atom coordinates
+   from RDKit; shift them (add `dx`/`dy` to each `n p`) rather than relying on
+   ChemDraw auto-layout.
+4. **Validate by re-reading.** `rdChemReactions.ReactionsFromCDXMLBlock(text)`
+   should return the expected reactant/product counts if the `<step>` id
+   references are correct.

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
@@ -86,12 +86,12 @@ def _place(frag, cx: float, cy: float):
         n.set("p", f"{x + cx} {y + cy}")
 
 
-def _cell_center(i: int, cols: int):
+def _cell_center(i: int, cols: int, cell_w: float, cell_h: float):
     """Boustrophedon (snake) grid: row 0 left->right, row 1 right->left, ..."""
     row, col = divmod(i, cols)
     vis_col = col if row % 2 == 0 else (cols - 1 - col)
-    cx = MARGIN + vis_col * CELL_W + CELL_W / 2
-    cy = MARGIN + row * CELL_H + CELL_H / 2
+    cx = MARGIN + vis_col * cell_w + cell_w / 2
+    cy = MARGIN + row * cell_h + cell_h / 2
     return cx, cy, row, vis_col
 
 
@@ -117,17 +117,28 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
         obj_id += 1
         return obj_id
 
-    frag_ids, centers, bboxes = [], [], []
-    for i, step in enumerate(steps):
-        cx, cy, _, _ = _cell_center(i, cols)
+    # Pass 1: build every fragment centered on the origin and measure it, so the
+    # cell size can be derived from the LARGEST structure. Fixed cells overlap once
+    # a structure is wider than the cell; sizing to the biggest bbox prevents that.
+    built = []
+    for step in steps:
         fid = new_obj()
         frag, next_id, bbox = _fragment_for(step["smiles"], fid, next_id)
+        built.append((fid, frag, bbox, step))
+    max_w = max(2 * b[0] for _, _, b, _ in built)
+    max_h = max(2 * b[1] for _, _, b, _ in built)
+    cell_w = max(CELL_W, max_w + 150)   # + room for the arrow and conditions text
+    cell_h = max(CELL_H, max_h + 130)   # + room for the name label and conditions
+
+    # Pass 2: place each fragment at its cell center; add the name label.
+    frag_ids, centers, bboxes = [], [], []
+    for i, (fid, frag, bbox, step) in enumerate(built):
+        cx, cy, _, _ = _cell_center(i, cols, cell_w, cell_h)
         _place(frag, cx, cy)
         page.append(frag)
         frag_ids.append(fid)
         centers.append((cx, cy))
         bboxes.append(bbox)
-        # Name label centered under the structure.
         if step.get("name"):
             t = ET.SubElement(page, "t", {"id": str(new_obj()),
                                           "p": f"{cx} {cy + bbox[1] + 34}",

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
@@ -1,0 +1,211 @@
+"""
+build_reaction_scheme.py — Assemble a multi-step reaction scheme as ChemDraw CDXML
+and render it to PNG, with automatic grid layout, globally unique object ids, and
+conditions text placed in the clear gap over each arrow (never on a structure).
+
+Why this exists: hand-assembling scheme CDXML repeatedly produces the same defects
+— duplicate object ids, each arrow emitted twice, and conditions text overlapping
+the neighbouring structure. This helper does the bookkeeping mechanically so those
+classes of bug cannot occur, and always writes the PNG alongside the CDXML.
+
+Usage (library):
+    from build_reaction_scheme import build_scheme
+    steps = [
+        {"smiles": "O=C1CCCC1", "name": "cyclopentanone"},
+        # `conditions` are the reagents for the arrow LEADING INTO this step:
+        {"smiles": "O=C1C(Br)C(Br)C(Br)C1Br", "name": "tetrabromide",
+         "conditions": ["Br2 (excess)", "AcOH, 25 C"]},
+        ...
+    ]
+    build_scheme(steps, "scheme.cdxml", "scheme.png", title="My Synthesis", cols=4)
+
+Usage (CLI):
+    python build_reaction_scheme.py steps.json scheme.cdxml scheme.png "My Synthesis"
+    # steps.json is a JSON list of the step dicts shown above.
+
+Requires: rdkit (built with ChemDraw write support); epam.indigo only if a PNG is
+requested. Runnable from the repo root.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdDepictor
+
+# Layout constants (ChemDraw units; default bond length 30, y increases downward).
+CELL_W = 320.0   # horizontal pitch between structure centers
+CELL_H = 320.0   # vertical pitch between rows
+MARGIN = 60.0
+ARROW_GAP = 14.0  # clearance between a structure edge and an arrow end
+COND_DY = 22.0    # first conditions line offset above a horizontal arrow
+
+
+def _fragment_for(smiles: str, frag_id: int, first_atom_id: int):
+    """Return (fragment_element, next_id, bbox) with globally unique ids, centered on 0,0."""
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"invalid SMILES: {smiles}")
+    rdDepictor.SetPreferCoordGen(True)
+    rdDepictor.Compute2DCoords(mol)
+    frag = ET.fromstring(rdChemDraw.MolToChemDrawBlock(mol)).find("page/fragment")
+
+    # Renumber every id in the fragment into a private block so no two fragments collide.
+    remap: dict[str, str] = {}
+    nid = first_atom_id
+    frag.set("id", str(frag_id))
+    for el in list(frag.iter("n")) + list(frag.iter("b")):
+        remap[el.get("id")] = str(nid)
+        el.set("id", str(nid))
+        nid += 1
+    for b in frag.iter("b"):
+        b.set("B", remap[b.get("B")])
+        b.set("E", remap[b.get("E")])
+
+    # Center the fragment on the origin so callers can translate it to a cell center.
+    xs, ys = [], []
+    for n in frag.iter("n"):
+        x, y = map(float, n.get("p").split())
+        xs.append(x)
+        ys.append(y)
+    cx, cy = (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2
+    for n in frag.iter("n"):
+        x, y = map(float, n.get("p").split())
+        n.set("p", f"{x - cx} {y - cy}")
+    half_w, half_h = (max(xs) - min(xs)) / 2, (max(ys) - min(ys)) / 2
+    return frag, nid, (half_w, half_h)
+
+
+def _place(frag, cx: float, cy: float):
+    """Translate a centered fragment to canvas center (cx, cy)."""
+    for n in frag.iter("n"):
+        x, y = map(float, n.get("p").split())
+        n.set("p", f"{x + cx} {y + cy}")
+
+
+def _cell_center(i: int, cols: int):
+    """Boustrophedon (snake) grid: row 0 left->right, row 1 right->left, ..."""
+    row, col = divmod(i, cols)
+    vis_col = col if row % 2 == 0 else (cols - 1 - col)
+    cx = MARGIN + vis_col * CELL_W + CELL_W / 2
+    cy = MARGIN + row * CELL_H + CELL_H / 2
+    return cx, cy, row, vis_col
+
+
+def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
+    """Build a scheme CDXML from a list of step dicts; optionally render a PNG.
+
+    Returns (cdxml_path, png_path_or_None).
+    """
+    root = ET.Element("CDXML", {"BondLength": "30", "LabelFont": "21",
+                                "LabelSize": "10", "CaptionFont": "21", "CaptionSize": "10"})
+    ft = ET.SubElement(root, "fonttable")
+    ET.SubElement(ft, "font", {"id": "21", "charset": "iso-8859-1", "name": "Arial"})
+    ct = ET.SubElement(root, "colortable")
+    for r, g, b in [(1, 1, 1), (0, 0, 0)]:
+        ET.SubElement(ct, "color", {"r": str(r), "g": str(g), "b": str(b)})
+    page = ET.SubElement(root, "page")
+    scheme = ET.SubElement(page, "scheme", {"id": "1"})
+
+    next_id = 1000          # atom/bond id counter (fragment interiors)
+    obj_id = 100            # ids for fragments, arrows, text, steps
+    def new_obj():
+        nonlocal obj_id
+        obj_id += 1
+        return obj_id
+
+    frag_ids, centers, bboxes = [], [], []
+    for i, step in enumerate(steps):
+        cx, cy, _, _ = _cell_center(i, cols)
+        fid = new_obj()
+        frag, next_id, bbox = _fragment_for(step["smiles"], fid, next_id)
+        _place(frag, cx, cy)
+        page.append(frag)
+        frag_ids.append(fid)
+        centers.append((cx, cy))
+        bboxes.append(bbox)
+        # Name label centered under the structure.
+        if step.get("name"):
+            t = ET.SubElement(page, "t", {"id": str(new_obj()),
+                                          "p": f"{cx} {cy + bbox[1] + 34}",
+                                          "Justification": "Center"})
+            ET.SubElement(t, "s", {"font": "21", "size": "10", "color": "0",
+                                   "face": "0"}).text = step["name"]
+
+    # Arrows + conditions between consecutive structures.
+    for i in range(len(steps) - 1):
+        (ax, ay), (bx, by) = centers[i], centers[i + 1]
+        (ahw, ahh), (bhw, bhh) = bboxes[i], bboxes[i + 1]
+        cond = steps[i + 1].get("conditions", [])
+        arrow_id = new_obj()
+        if abs(ay - by) < 1.0:          # same row -> horizontal arrow in the gap
+            if bx > ax:                 # pointing right
+                tail_x, head_x = ax + ahw + ARROW_GAP, bx - bhw - ARROW_GAP
+            else:                       # snake row: pointing left
+                tail_x, head_x = ax - ahw - ARROW_GAP, bx + bhw + ARROW_GAP
+            ET.SubElement(page, "arrow", {
+                "id": str(arrow_id), "FillType": "None", "ArrowheadType": "Solid",
+                "ArrowheadHead": "Full", "HeadSize": "1500",
+                "Head3D": f"{head_x} {ay} 0", "Tail3D": f"{tail_x} {ay} 0"})
+            mid_x = (tail_x + head_x) / 2
+            for k, line in enumerate(cond):
+                t = ET.SubElement(page, "t", {"id": str(new_obj()),
+                                              "p": f"{mid_x} {ay - COND_DY - 14 * (len(cond) - 1 - k)}",
+                                              "Justification": "Center"})
+                ET.SubElement(t, "s", {"font": "21", "size": "9", "color": "0",
+                                       "face": "0"}).text = line
+        else:                           # row change -> vertical arrow (same column)
+            tail_y, head_y = ay + ahh + ARROW_GAP, by - bhh - ARROW_GAP
+            ET.SubElement(page, "arrow", {
+                "id": str(arrow_id), "FillType": "None", "ArrowheadType": "Solid",
+                "ArrowheadHead": "Full", "HeadSize": "1500",
+                "Head3D": f"{ax} {head_y} 0", "Tail3D": f"{ax} {tail_y} 0"})
+            mid_y = (tail_y + head_y) / 2
+            for k, line in enumerate(cond):
+                t = ET.SubElement(page, "t", {"id": str(new_obj()),
+                                              "p": f"{ax + 16} {mid_y - 7 + 14 * k}",
+                                              "Justification": "Left"})
+                ET.SubElement(t, "s", {"font": "21", "size": "9", "color": "0",
+                                       "face": "0"}).text = line
+        # Wire the reaction step (ids only; geometry lives on the page objects).
+        ET.SubElement(scheme, "step", {
+            "id": str(new_obj()),
+            "ReactionStepReactants": str(frag_ids[i]),
+            "ReactionStepProducts": str(frag_ids[i + 1]),
+            "ReactionStepArrows": str(arrow_id)})
+
+    if title:
+        t = ET.SubElement(page, "t", {"id": str(new_obj()),
+                                      "p": f"{MARGIN} {MARGIN - 34}", "Justification": "Left"})
+        ET.SubElement(t, "s", {"font": "21", "size": "16", "color": "0", "face": "1"}).text = title
+
+    cdxml = ET.tostring(root, encoding="unicode")
+    Path(out_cdxml).write_text('<?xml version="1.0" encoding="UTF-8"?>\n' + cdxml, encoding="utf-8")
+
+    png_path = None
+    if out_png:
+        from indigo import Indigo
+        from indigo.renderer import IndigoRenderer
+        ind = Indigo()
+        rnd = IndigoRenderer(ind)
+        ind.setOption("render-output-format", "png")
+        ind.setOption("render-background-color", "1,1,1")
+        ind.setOption("render-image-width", 1800)
+        rnd.renderToFile(ind.loadReaction(cdxml), out_png)
+        png_path = out_png
+    return out_cdxml, png_path
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+    steps = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    out_cdxml = sys.argv[2]
+    out_png = sys.argv[3] if len(sys.argv) > 3 else None
+    title = sys.argv[4] if len(sys.argv) > 4 else None
+    c, p = build_scheme(steps, out_cdxml, out_png, title=title)
+    print(f"Wrote {c}" + (f" + {p}" if p else ""))

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
@@ -194,20 +194,29 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
         ET.SubElement(t, "s", {"font": "21", "size": "16", "color": "0", "face": "1"}).text = title
 
     cdxml = ET.tostring(root, encoding="unicode")
+    # Fail loudly on malformed XML instead of writing a file ChemDraw would reject.
+    ET.fromstring(cdxml)
     Path(out_cdxml).write_text('<?xml version="1.0" encoding="UTF-8"?>\n' + cdxml, encoding="utf-8")
 
-    png_path = None
-    if out_png:
+    # The PNG is not optional: a .cdxml is not viewable without ChemDraw, so the
+    # preview is the only evidence the file is correct. Render it or raise.
+    if out_png is None:
+        out_png = str(Path(out_cdxml).with_suffix(".png"))
+    try:
         from indigo import Indigo
         from indigo.renderer import IndigoRenderer
-        ind = Indigo()
-        rnd = IndigoRenderer(ind)
-        ind.setOption("render-output-format", "png")
-        ind.setOption("render-background-color", "1,1,1")
-        ind.setOption("render-image-width", 1800)
-        rnd.renderToFile(ind.loadReaction(cdxml), out_png)
-        png_path = out_png
-    return out_cdxml, png_path
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise RuntimeError(
+            "PNG rendering needs the 'epam.indigo' package (pip install epam.indigo). "
+            "Never deliver a .cdxml without its PNG preview."
+        ) from exc
+    ind = Indigo()
+    rnd = IndigoRenderer(ind)
+    ind.setOption("render-output-format", "png")
+    ind.setOption("render-background-color", "1,1,1")
+    ind.setOption("render-image-width", 1800)
+    rnd.renderToFile(ind.loadReaction(cdxml), out_png)
+    return out_cdxml, out_png
 
 
 if __name__ == "__main__":

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
@@ -140,9 +140,12 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
         centers.append((cx, cy))
         bboxes.append(bbox)
         if step.get("name"):
+            # A structure that ends a row gets a vertical arrow out of its bottom;
+            # put its name ABOVE so the label never sits on that arrow.
+            vertical_source = (i % cols == cols - 1) and (i < len(built) - 1)
+            name_y = cy - bbox[1] - 22 if vertical_source else cy + bbox[1] + 34
             t = ET.SubElement(page, "t", {"id": str(new_obj()),
-                                          "p": f"{cx} {cy + bbox[1] + 34}",
-                                          "Justification": "Center"})
+                                          "p": f"{cx} {name_y}", "Justification": "Center"})
             ET.SubElement(t, "s", {"font": "21", "size": "10", "color": "0",
                                    "face": "0"}).text = step["name"]
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/check_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/check_scheme.py
@@ -43,7 +43,10 @@ from rdkit.Chem import rdChemDraw, rdMolDescriptors
 BOND_MIN, BOND_MAX = 20.0, 45.0      # acceptable drawn bond-length window (units)
 COINCIDENT = 8.0                     # non-bonded atoms closer than this overlap
 ON_BOND = 6.0                        # atom-to-unrelated-bond distance that reads as "on it"
+ON_ARROW = 10.0                      # text-anchor-to-arrow-line distance that reads as overlapping
 CHAR_W = 5.5                         # approx width of one size-9 character (units)
+# Decorative stereo flags to keep out of schemes — draw wedge bonds instead.
+FLAG_WORDS = {"chiral", "achiral", "racemic", "(+/-)", "(±)", "meso"}
 
 
 def _atoms(frag):
@@ -194,7 +197,7 @@ def geometry_check(cdxml_path, perspective_ids=()):
     for aid, c in acount.items():
         if c > 1:
             problems.append(f"arrow id {aid} written {c} times")
-    arrow_spans = []
+    arrow_spans, arrow_segs = [], []
     for a in arrows:
         if a.get("Head3D") and a.get("Tail3D"):
             hx, hy, _ = map(float, a.get("Head3D").split())
@@ -203,20 +206,28 @@ def geometry_check(cdxml_path, perspective_ids=()):
             if L < 15:
                 problems.append(f"arrow {a.get('id')} degenerate (length {L:.1f})")
             arrow_spans.append(((hx + tx) / 2, (hy + ty) / 2, L))
+            arrow_segs.append(((tx, ty), (hx, hy)))
 
-    # text: non-ASCII, and conditions wider than the nearest arrow
+    # text: decorative flag words, non-ASCII, overlap with an arrow line, over-wide
     for t in root.iter("t"):
         s = "".join(x.text or "" for x in t.iter("s"))
+        if s.strip().lower() in FLAG_WORDS:
+            problems.append(f"decorative flag text '{s.strip()}' — remove it; show stereo with wedge bonds")
         try:
             s.encode("ascii")
         except UnicodeEncodeError:
             bad = [ch for ch in s if ord(ch) > 127]
             problems.append(f"text '{s[:25]}' has non-ASCII {bad} (font table is iso-8859-1)")
-        if t.get("p") and arrow_spans:
+        if t.get("p"):
             tx, ty = map(float, t.get("p").split())
-            mx, my, L = min(arrow_spans, key=lambda m: (m[0] - tx) ** 2 + (m[1] - ty) ** 2)
-            if abs(my - ty) < 40 and len(s) * CHAR_W > L * 1.4:
-                infos.append(f"text '{s[:25]}' (~{len(s)*CHAR_W:.0f}u) wider than its arrow ({L:.0f}u)")
+            for p0, p1 in arrow_segs:                       # text anchor sitting on an arrow line
+                if _seg_dist((tx, ty), p0, p1) < ON_ARROW:
+                    problems.append(f"text '{s[:25]}' overlaps an arrow (move it clear of the arrow line)")
+                    break
+            if arrow_spans:                                 # conditions text wider than its arrow
+                mx, my, L = min(arrow_spans, key=lambda m: (m[0] - tx) ** 2 + (m[1] - ty) ** 2)
+                if abs(my - ty) < 40 and len(s) * CHAR_W > L * 1.4:
+                    infos.append(f"text '{s[:25]}' (~{len(s)*CHAR_W:.0f}u) wider than its arrow ({L:.0f}u)")
 
     for p in problems:
         print(f"  ! {p}")

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/check_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/check_scheme.py
@@ -1,0 +1,243 @@
+"""
+check_scheme.py — Validate and critique a ChemDraw CDXML scheme before delivery.
+
+Three independent passes, none of which subsumes the others:
+
+1. validate_structures() rebuilds every molecule in RDKit **from the CDXML drawing
+   itself** (not from a SMILES you typed separately), sanitizes it (catching valence
+   errors), prints its molecular formula and canonical SMILES, and compares against
+   any reference SMILES you can state independently. Validating a parallel SMILES
+   string is pointless — a mismatch between that string and the drawing goes
+   undetected; rebuilding from the drawing is the whole point.
+
+2. mass_balance() prints the formula of each structure in order so you can check it
+   against the reaction arrows by hand: a protection adds exactly the protecting
+   group, a decarboxylation removes exactly CO2, a photochemical isomerisation does
+   not change the formula at all. This catches connectivity slips sanitization allows.
+
+3. geometry_check() flags duplicate object ids, overlapping structures, non-bonded
+   atoms drawn on top of each other, atoms sitting on an unrelated bond, bond
+   crossings, degenerate/duplicate arrows, non-ASCII text (the font table is
+   iso-8859-1), and conditions text wider than its arrow. Pass perspective_ids for
+   fragments whose foreshortened bonds and crossings are intentional (cages, bridged
+   bicyclics) so they are reported as info (.) rather than problems (!).
+
+check_all() runs all three and returns the problem count. Drive it to zero.
+
+Usage:
+    from check_scheme import check_all
+    n = check_all("scheme.cdxml", expect={10: "C12C3C4C1C5C2C3C45"}, perspective_ids={"6100"})
+    assert n == 0
+"""
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+
+from rdkit import Chem
+from rdkit.Chem import rdChemDraw, rdMolDescriptors
+
+BOND_MIN, BOND_MAX = 20.0, 45.0      # acceptable drawn bond-length window (units)
+COINCIDENT = 8.0                     # non-bonded atoms closer than this overlap
+ON_BOND = 6.0                        # atom-to-unrelated-bond distance that reads as "on it"
+CHAR_W = 5.5                         # approx width of one size-9 character (units)
+
+
+def _atoms(frag):
+    return {n.get("id"): tuple(map(float, n.get("p").split()))
+            for n in frag.iter("n") if n.get("p")}
+
+
+def _bonds(frag):
+    return [(b.get("B"), b.get("E")) for b in frag.iter("b")]
+
+
+def _seg_dist(p, a, b):
+    """Distance from point p to segment ab."""
+    (px, py), (ax, ay), (bx, by) = p, a, b
+    dx, dy = bx - ax, by - ay
+    if dx == dy == 0:
+        return ((px - ax) ** 2 + (py - ay) ** 2) ** 0.5
+    t = max(0.0, min(1.0, ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)))
+    cx, cy = ax + t * dx, ay + t * dy
+    return ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
+
+
+def _segments_cross(p1, p2, p3, p4):
+    """True if open segments p1p2 and p3p4 properly intersect."""
+    def ccw(a, b, c):
+        return (c[1] - a[1]) * (b[0] - a[0]) - (b[1] - a[1]) * (c[0] - a[0])
+    d1, d2 = ccw(p3, p4, p1), ccw(p3, p4, p2)
+    d3, d4 = ccw(p1, p2, p3), ccw(p1, p2, p4)
+    return ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0))
+
+
+def validate_structures(cdxml_path, expect=None):
+    """Rebuild each drawn molecule in RDKit, sanitize, print formula/SMILES, compare."""
+    expect = expect or {}
+    txt = Path(cdxml_path).read_text(encoding="utf-8")
+    mols = rdChemDraw.MolsFromChemDrawBlock(txt, sanitize=False)
+    problems = []
+    print(f"[validate] {len(mols)} structure(s) rebuilt from the drawing:")
+    for i, m in enumerate(mols):
+        try:
+            Chem.SanitizeMol(m)
+            formula = rdMolDescriptors.CalcMolFormula(m)
+            smi = Chem.MolToSmiles(m)
+        except Exception as e:
+            problems.append(f"structure {i}: valence/sanitize error ({str(e)[:50]})")
+            print(f"  ! [{i}] SANITIZE FAILED: {str(e)[:60]}")
+            continue
+        tag, mark = "", "."
+        if i in expect:
+            ref = Chem.MolFromSmiles(expect[i])
+            if ref is None:
+                problems.append(f"structure {i}: reference SMILES '{expect[i]}' is invalid")
+                tag, mark = "  [BAD REFERENCE SMILES]", "!"
+            elif Chem.MolToSmiles(ref) == smi:
+                tag = "  [MATCH]"
+            else:
+                problems.append(f"structure {i}: drawn {smi} != expected {expect[i]}")
+                tag, mark = f"  [MISMATCH expected {expect[i]}]", "!"
+        print(f"  {mark} [{i}] {formula:12} {smi}{tag}")
+    return problems
+
+
+def mass_balance(cdxml_path):
+    """Print each structure's formula in order for a by-hand arrow mass-balance check."""
+    txt = Path(cdxml_path).read_text(encoding="utf-8")
+    mols = rdChemDraw.MolsFromChemDrawBlock(txt, sanitize=False)
+    print("[mass balance] formula per structure (check deltas against your arrows):")
+    prev = None
+    for i, m in enumerate(mols):
+        try:
+            Chem.SanitizeMol(m)
+            f = rdMolDescriptors.CalcMolFormula(m)
+        except Exception:
+            f = "<invalid>"
+        delta = ""
+        if prev and f != "<invalid>":
+            delta = f"   (prev -> this)"
+        print(f"  [{i}] {f}{delta}")
+        prev = f
+
+
+def geometry_check(cdxml_path, perspective_ids=()):
+    """Layout and drawing critic. Returns list of problem strings; prints ! / . report."""
+    perspective_ids = set(perspective_ids)
+    root = ET.fromstring(Path(cdxml_path).read_text(encoding="utf-8"))
+    problems, infos = [], []
+
+    # duplicate object ids
+    ids = [e.get("id") for e in root.iter() if e.get("id")]
+    dups = [i for i, c in Counter(ids).items() if c > 1]
+    if dups:
+        problems.append(f"duplicate ids: {dups}")
+
+    frags = root.findall(".//fragment")
+    # fragment bounding boxes -> overlap between different structures
+    def fbbox(fr):
+        xs = [p[0] for p in _atoms(fr).values()]
+        ys = [p[1] for p in _atoms(fr).values()]
+        return (min(xs), min(ys), max(xs), max(ys))
+    boxes = [(fr.get("id"), fbbox(fr)) for fr in frags]
+    for (ida, a), (idb, b) in combinations(boxes, 2):
+        if not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1]):
+            problems.append(f"fragments {ida} and {idb} overlap")
+
+    # per-fragment intramolecular checks
+    for fr in frags:
+        fid = fr.get("id")
+        persp = fid in perspective_ids
+        atoms, bonds = _atoms(fr), _bonds(fr)
+        bonded = {frozenset(b) for b in bonds}
+        # bond lengths
+        for B, E in bonds:
+            if B in atoms and E in atoms:
+                d = ((atoms[B][0] - atoms[E][0]) ** 2 + (atoms[B][1] - atoms[E][1]) ** 2) ** 0.5
+                if not (BOND_MIN <= d <= BOND_MAX):
+                    (infos if persp else problems).append(
+                        f"fragment {fid}: bond {B}-{E} length {d:.1f} out of [{BOND_MIN},{BOND_MAX}]")
+        # Intramolecular drawing checks are info-only: a 2D projection of a cage or
+        # bridged bicyclic legitimately has crossings and near-coincident atoms.
+        # Pass the fragment id in perspective_ids to silence them entirely.
+        if persp:
+            continue
+        # non-bonded coincident atoms
+        for i1, i2 in combinations(atoms, 2):
+            if frozenset((i1, i2)) in bonded:
+                continue
+            d = ((atoms[i1][0] - atoms[i2][0]) ** 2 + (atoms[i1][1] - atoms[i2][1]) ** 2) ** 0.5
+            if d < COINCIDENT:
+                infos.append(f"fragment {fid}: non-bonded atoms {i1},{i2} coincide (d={d:.1f})")
+        # atom sitting on an unrelated bond
+        for aid, ap in atoms.items():
+            for B, E in bonds:
+                if aid in (B, E) or B not in atoms or E not in atoms:
+                    continue
+                if _seg_dist(ap, atoms[B], atoms[E]) < ON_BOND:
+                    infos.append(f"fragment {fid}: atom {aid} sits on bond {B}-{E}")
+        # bond crossings
+        for (b1, b2) in combinations(bonds, 2):
+            if set(b1) & set(b2):
+                continue
+            if all(x in atoms for x in (*b1, *b2)) and _segments_cross(
+                    atoms[b1[0]], atoms[b1[1]], atoms[b2[0]], atoms[b2[1]]):
+                infos.append(f"fragment {fid}: bonds {b1} and {b2} cross")
+
+    # arrows: degenerate / duplicate
+    arrows = root.findall(".//arrow")
+    acount = Counter(a.get("id") for a in arrows)
+    for aid, c in acount.items():
+        if c > 1:
+            problems.append(f"arrow id {aid} written {c} times")
+    arrow_spans = []
+    for a in arrows:
+        if a.get("Head3D") and a.get("Tail3D"):
+            hx, hy, _ = map(float, a.get("Head3D").split())
+            tx, ty, _ = map(float, a.get("Tail3D").split())
+            L = ((hx - tx) ** 2 + (hy - ty) ** 2) ** 0.5
+            if L < 15:
+                problems.append(f"arrow {a.get('id')} degenerate (length {L:.1f})")
+            arrow_spans.append(((hx + tx) / 2, (hy + ty) / 2, L))
+
+    # text: non-ASCII, and conditions wider than the nearest arrow
+    for t in root.iter("t"):
+        s = "".join(x.text or "" for x in t.iter("s"))
+        try:
+            s.encode("ascii")
+        except UnicodeEncodeError:
+            bad = [ch for ch in s if ord(ch) > 127]
+            problems.append(f"text '{s[:25]}' has non-ASCII {bad} (font table is iso-8859-1)")
+        if t.get("p") and arrow_spans:
+            tx, ty = map(float, t.get("p").split())
+            mx, my, L = min(arrow_spans, key=lambda m: (m[0] - tx) ** 2 + (m[1] - ty) ** 2)
+            if abs(my - ty) < 40 and len(s) * CHAR_W > L * 1.4:
+                infos.append(f"text '{s[:25]}' (~{len(s)*CHAR_W:.0f}u) wider than its arrow ({L:.0f}u)")
+
+    for p in problems:
+        print(f"  ! {p}")
+    for inf in infos:
+        print(f"  . {inf}")
+    print(f"[geometry] {len(problems)} problem(s), {len(infos)} info")
+    return problems
+
+
+def check_all(cdxml_path, expect=None, perspective_ids=()):
+    """Run all three passes; return total problem count. Aim for 0."""
+    p1 = validate_structures(cdxml_path, expect)
+    mass_balance(cdxml_path)
+    p3 = geometry_check(cdxml_path, perspective_ids)
+    total = len(p1) + len(p3)
+    print(f"\n=== {total} problem(s) total — {'OK to deliver' if total == 0 else 'FIX before delivering'} ===")
+    return total
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    sys.exit(1 if check_all(sys.argv[1]) else 0)


### PR DESCRIPTION
## Summary

Adds a **Toolkit** skill for reading, writing, and editing ChemDraw **CDX/CDXML** files, under `structural-biology-drug-discovery`.

The skill is a **hybrid** of RDKit's `rdkit.Chem.rdChemDraw` (structure/reaction I/O + 2D depiction) and **direct CDXML XML editing** — because RDKit writes molecule structures only. Reaction arrows, plus signs, reaction schemes/steps, and free text/labels are ChemDraw canvas objects that must be built at the XML level.

### Files
- `skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md` — 8 Core API modules (read mols, read reactions, write structures, good depiction, arrows, schemes/steps, text/labels, edit existing files), 3 end-to-end workflows, 11 best practices, 12-row troubleshooting
- `skills/.../rdkit-chemdraw-cdxml/references/cdxml-schema-reference.md` — element/attribute cheat-sheet (`n`/`b`/`arrow`/`graphic`/`step`/`scheme`/`t`/`s`/`fonttable`/`colortable`), coordinate conventions, enum tables, and a copy-paste document header
- `registry.yaml` — new entry (`sub_type: toolkit`)

## How it was verified

All API facts were confirmed empirically against RDKit 2026.03.4, not assumed:
- `rdChemDraw` function signatures via introspection; `HasChemDrawCDXSupport() == True`
- Real ChemDraw-authored CDXML markup (`<arrow>`, `<step>`, `<t><s>`) taken from RDKit's own test fixtures
- A hand-built reaction CDXML round-trips correctly through `ReactionsFromCDXMLBlock`

### Key pitfalls documented (from real good/bad generated examples)
- **RDKit `Mol` round-trip silently drops arrows and text** — editing a reaction must be done on the XML tree
- `rdChemDraw.MolToChemDrawBlock(..., CDX)` raises `UnicodeDecodeError`; use legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` for CDX bytes
- No redundant free-text atom labels on `Element` nodes (double-render bug)
- Uniform bond length across fragments; every reaction step needs a real arrow; subscript formulas via split `<s>` runs; XML escaping

## Test plan
- [x] `pixi run validate` — registry OK
- [x] `pixi run test` — full suite passes (4120 passed)
- [x] New code snippets execute and produce valid CDXML

🤖 Generated with [Claude Code](https://claude.com/claude-code)