### PR TITLE
feat: cdxml scheme layout/typography polish + helper-copy fix

### DIFF
--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -32,10 +32,11 @@ A `.cdxml` is not viewable without ChemDraw, and **you cannot run ChemDraw here*
 
 - **Python packages**: `rdkit` (2023.03+, built with ChemDraw support), `epam.indigo` (renders CDXML→PNG); `xml.etree.ElementTree` (stdlib) handles all XML editing.
 - **Inputs**: SMILES/Mol for writing; `.cdxml` (UTF-8 text) or `.cdx` (binary) for reading.
-- **Check before installing.** RDKit is usually already present in a managed env — run `python -c "import rdkit"` first; inside pixi use `pixi run python ...`.
+- **Check before installing.** RDKit is usually already present — run `python -c "import rdkit"` first; inside pixi use `pixi run python ...`.
+- **Install `epam.indigo` into the interpreter that runs your code.** A bare `pip install` can land in a different Python than the kernel (e.g. system `/usr/local` vs the pixi env that has rdkit), so `import indigo` still fails even though the install "succeeded" — and no single interpreter then has both rdkit and indigo. In a Jupyter/IPython kernel use `%pip install epam.indigo`; otherwise `python -m pip install epam.indigo` (the running interpreter), or add it to the project env (`pixi add epam.indigo`). For the same reason, **do not run the build/render in a fresh `subprocess`** (`["python", …]` may resolve yet another interpreter) — import the helper and run it in the current process.
 
 ```bash
-pip install rdkit epam.indigo   # only if missing
+python -m pip install epam.indigo   # the running interpreter; or  %pip install epam.indigo  in Jupyter
 python -c "from rdkit import Chem; print('ChemDraw write support:', Chem.HasChemDrawCDXSupport())"
 ```
 
@@ -421,6 +422,7 @@ print(minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
 | A name or label sits on an arrow | Text placed on the arrow line | Names go under the structure, conditions offset above/beside the arrow; `check_scheme` flags text on an arrow |
 | `stoi: no conversion` loading in Indigo | `<CDXML BondLength="">` empty | Set a numeric `BondLength` (e.g. `30`) before rendering |
 | `ModuleNotFoundError`/`FileNotFoundError` on a helper script | `import`ed or `open()`ed the `/SciAgent-Skills/...` path from Python | That path is reachable only via the read-file tool, not the sandbox filesystem — copy the script into the workdir first (Workflow 4), then import |
+| `import indigo` fails after a "successful" `pip install` | pip installed into a different Python than the runtime (system `/usr/local` vs the pixi/kernel env) | Install into the running interpreter (`%pip install` or `python -m pip install`), or `pixi add epam.indigo`; don't shell out to a different `python` |
 | A charge (`H+`) renders as a giant `+` | Indigo draws a standalone `+` as a reaction-plus symbol, and superscript (face 64) mangles ion text | Keep charges inline (`H+`, `OH-`), face 0 — a true raised superscript is not achievable in the Indigo preview. Subscripts (face 32) and `°C`/`Δ` render fine |
 
 ## Bundled Resources

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/SKILL.md
@@ -164,7 +164,7 @@ print(ET.tostring(scheme, encoding="unicode"))
 
 ### Module 7: Adding text and labels
 
-Free text is a `<t>` at `p="x y"` holding one or more `<s>` styled-string children. `<s>` references a `font` id (`<fonttable>`) and `color` index (`<colortable>`); `face` is a bitmask (1=bold, 2=italic, 32=subscript, 64=superscript). Split a `<t>` into multiple `<s>` runs for subscripts (`Br₂`, `CO₂H`). **Keep text ASCII** — the font table is iso-8859-1, so write `hv` not `hν`, `25 C` not `25 °C`, `heat` not `Δ`.
+Free text is a `<t>` at `p="x y"` holding one or more `<s>` styled-string children. `<s>` references a `font` id (`<fonttable>`) and `color` index (`<colortable>`); `face` is a bitmask (1=bold, 2=italic, 32=subscript, 64=superscript). Split a `<t>` into multiple `<s>` runs for subscripts (`Br₂`, `CO₂H`). Indigo renders **subscript (32) but not superscript (64)** — it drops the run's leading text — so keep charges inline (`H+`, `OH-`). `°C` (temperatures) and `Δ` (heat) render with the Arial font; avoid other non-Latin-1 characters (`hν`, en-dashes).
 
 ```python
 import xml.etree.ElementTree as ET
@@ -332,18 +332,15 @@ tree.write("output_reaction.cdxml", encoding="unicode", xml_declaration=True)
 
 `scripts/build_reaction_scheme.py` turns `(smiles, name, conditions)` steps into a laid-out scheme **and its PNG in one call**, handling grid layout, globally unique ids, single arrows, and conditions text placed clear of structures — the defects that recur when schemes are hand-built. Cells auto-size to the largest structure, so big molecules never overlap. Model convergent/multi-component steps by folding co-reactants into `conditions` (e.g. `["+ (MeO2C)2C=CHOMe", "Base, MeCN"]`), keeping one main-chain structure per cell.
 
-The `scripts/` files can be **read** from the skill path but **not imported** from there — they are not on the execution sandbox's import path. Copy the two you need into your working directory first, then import. Each script depends only on rdkit (+ epam.indigo), never on the other, so copy them independently:
+**Copy the scripts into your working directory with your file tools — not from Python.** Inside the execution sandbox the `/SciAgent-Skills/...` path is reachable **only through your read-file tool**; it is not on the sandbox filesystem, so a Python `open()` or `import` of that path fails with `FileNotFoundError`/`ModuleNotFoundError`. For each of `build_reaction_scheme.py` and `check_scheme.py` (each is self-contained — rdkit + epam.indigo only — copy just what you need):
+
+1. **Read-file tool** on `/SciAgent-Skills/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/<name>` (the leading slash routes to the skills backend) → returns the script text.
+2. **Write-file tool** → save it to `./<name>` in the working directory.
+
+Then import the local copies. (Importing writes a harmless `__pycache__/`; set `PYTHONDONTWRITEBYTECODE=1` to suppress it.)
 
 ```python
-# 1) Copy the helpers into the workdir. Use the LEADING-SLASH skill path so the
-#    read routes to the skills backend (a path without the leading "/" is looked
-#    up in the sandbox workdir, where the file does not exist):
-_SKILL = "/SciAgent-Skills/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts"
-for name in ("build_reaction_scheme.py", "check_scheme.py"):
-    open(name, "w").write(read_file(f"{_SKILL}/{name}"))   # read_file = your file tool
-
-# 2) Now they import normally from the workdir:
-from build_reaction_scheme import build_scheme
+from build_reaction_scheme import build_scheme    # local copies, already in the workdir
 from check_scheme import check_all
 
 steps = [
@@ -378,7 +375,7 @@ print(f"Deliverables: {cdxml} + {png}")
 3. **Keep object ids globally unique.** Merging RDKit outputs (each starts at 1) collides and breaks `<step>` references and doubles arrows; renumber into disjoint blocks.
 4. **Prefer CDXML (text) over CDX (binary).** CDX write via `rdChemDraw` raises `UnicodeDecodeError`; only legacy `Chem.MolToCDXMLBlock(mol, CDXMLFormat.CDX)` returns valid CDX bytes.
 5. **Write a complete document header** — `<CDXML BondLength=...>` plus a standard `<fonttable>`/`<colortable>` and page dimensions. See `references/cdxml-schema-reference.md`.
-6. **Keep text ASCII** (font table is iso-8859-1); render heteroatoms via `<n Element=...>`, never as redundant free `<t>` text. Do **not** add decorative flag words like "Chiral"/"racemic" — show stereochemistry with wedge bonds. Keep every label clear of the arrow line: compound names go under their structure, conditions go offset above/beside the arrow, never on it.
+6. **Text**: use `°C` for temperatures and `Δ` for heat (both render); keep charges inline (`H+`, `OH-`) since Indigo has no superscript; avoid other non-Latin-1 characters. Render heteroatoms via `<n Element=...>`, not free `<t>` text; don't add decorative flags ("Chiral"/"racemic") — use wedge bonds. Keep labels clear of the arrow line: names under the structure, conditions offset above/beside the arrow. (`build_scheme` does all of this — `0 C`→`0 °C`, `heat`→`Δ`, subscripts, spacing — automatically.)
 7. **Deliver the CDXML and PNG together, and run `check_scheme.check_all` first.** The render and the critic catch overlaps, duplicate/degenerate arrows, dropped intermediates, and connectivity errors before the user sees them.
 
 ## Common Recipes
@@ -423,6 +420,8 @@ print(minidom.parseString(open("esterification.cdxml", encoding="utf-8").read())
 | "Chiral"/"racemic" printed above structures | Decorative flag text added as `<t>` | Remove it — stereochemistry is shown by wedge bonds; `check_scheme` flags it |
 | A name or label sits on an arrow | Text placed on the arrow line | Names go under the structure, conditions offset above/beside the arrow; `check_scheme` flags text on an arrow |
 | `stoi: no conversion` loading in Indigo | `<CDXML BondLength="">` empty | Set a numeric `BondLength` (e.g. `30`) before rendering |
+| `ModuleNotFoundError`/`FileNotFoundError` on a helper script | `import`ed or `open()`ed the `/SciAgent-Skills/...` path from Python | That path is reachable only via the read-file tool, not the sandbox filesystem — copy the script into the workdir first (Workflow 4), then import |
+| A charge (`H+`) renders as a giant `+` | Indigo draws a standalone `+` as a reaction-plus symbol, and superscript (face 64) mangles ion text | Keep charges inline (`H+`, `OH-`), face 0 — a true raised superscript is not achievable in the Indigo preview. Subscripts (face 32) and `°C`/`Δ` render fine |
 
 ## Bundled Resources
 

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/build_reaction_scheme.py
@@ -29,6 +29,7 @@ requested. Runnable from the repo root.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -86,13 +87,34 @@ def _place(frag, cx: float, cy: float):
         n.set("p", f"{x + cx} {y + cy}")
 
 
-def _cell_center(i: int, cols: int, cell_w: float, cell_h: float):
-    """Boustrophedon (snake) grid: row 0 left->right, row 1 right->left, ..."""
-    row, col = divmod(i, cols)
-    vis_col = col if row % 2 == 0 else (cols - 1 - col)
-    cx = MARGIN + vis_col * cell_w + cell_w / 2
-    cy = MARGIN + row * cell_h + cell_h / 2
-    return cx, cy, row, vis_col
+def _chem_runs(text: str):
+    """Split text into (segment, face) runs for ChemDraw <s>: a digit right after a
+    letter or ')' becomes a subscript (face 32); everything else stays normal (0).
+    Charges (+/-) are left inline rather than superscripted — Indigo does not render
+    superscript (face 64) correctly (it drops the preceding text). Keeps step numbers
+    ('1)'), temperatures ('0 C') and a leading '+ reagent' un-styled."""
+    runs, cur, cur_face = [], "", 0
+    for i, ch in enumerate(text):
+        prev = text[i - 1] if i else ""
+        face = 32 if (ch.isdigit() and (prev.isalpha() or prev == ")")) else 0
+        if face != cur_face and cur:
+            runs.append((cur, cur_face))
+            cur = ""
+        cur_face = face
+        cur += ch
+    if cur:
+        runs.append((cur, cur_face))
+    return runs or [(text, 0)]
+
+
+_TEMP_C = re.compile(r"(\d)\s*°?C\b")
+_HEAT = re.compile(r"\bheat\b", re.I)
+
+
+def _symbolize(text: str):
+    """Conditions typography: '<n> C' -> '<n> °C' (degree sign, Latin-1) and the
+    word 'heat' -> 'Δ'. Both render in Indigo with the Arial font table."""
+    return _HEAT.sub("Δ", _TEMP_C.sub(r"\1 °C", text))
 
 
 def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
@@ -126,37 +148,64 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
         frag, next_id, bbox = _fragment_for(step["smiles"], fid, next_id)
         built.append((fid, frag, bbox, step))
     max_w = max(2 * b[0] for _, _, b, _ in built)
-    max_h = max(2 * b[1] for _, _, b, _ in built)
-    cell_w = max(CELL_W, max_w + 150)   # + room for the arrow and conditions text
-    cell_h = max(CELL_H, max_h + 130)   # + room for the name label and conditions
+    cell_w = max(CELL_W, max_w + 150)   # global column pitch (+ arrow and text room)
+
+    # Row heights are sized to each row's OWN tallest structure, not the global
+    # maximum: otherwise a row of small molecules sits in tall cells and the
+    # vertical transition arrow stretches across a large empty band.
+    n = len(built)
+    n_rows = (n + cols - 1) // cols
+    row_members = [[j for j in range(n) if j // cols == r] for r in range(n_rows)]
+    row_h = [max(2 * built[j][2][1] for j in members) + 96 for members in row_members]
+    row_cy, acc = [], MARGIN
+    for r in range(n_rows):
+        row_cy.append(acc + row_h[r] / 2)
+        acc += row_h[r]
+
+    def cell_pos(i):
+        r, col = divmod(i, cols)
+        m = len(row_members[r])
+        # Boustrophedon (snake): even rows run left->right, odd rows right->left.
+        # A partial last row is spread across the full width so it doesn't leave a
+        # gaping column empty; the first member stays at the snake-start column so
+        # the vertical arrow from the row above still lands on it.
+        start, opp = (0, cols - 1) if r % 2 == 0 else (cols - 1, 0)
+        vis = float(start) if m <= 1 else start + (opp - start) * col / (m - 1)
+        return MARGIN + vis * cell_w + cell_w / 2, row_cy[r], vis
+
+    def add_text(x, y, s, size, just, bold=False):
+        t = ET.SubElement(page, "t", {"id": str(new_obj()), "p": f"{x} {y}",
+                                      "Justification": just})
+        for seg, face in _chem_runs(s):   # subscript/superscript chemical formulas
+            ET.SubElement(t, "s", {"font": "21", "size": str(size), "color": "0",
+                                   "face": str(face | (1 if bold else 0))}).text = seg
+        return t
 
     # Pass 2: place each fragment at its cell center; add the name label.
-    frag_ids, centers, bboxes = [], [], []
+    frag_ids, centers, bboxes, vcols = [], [], [], []
     for i, (fid, frag, bbox, step) in enumerate(built):
-        cx, cy, _, _ = _cell_center(i, cols, cell_w, cell_h)
+        cx, cy, vcol = cell_pos(i)
         _place(frag, cx, cy)
         page.append(frag)
         frag_ids.append(fid)
         centers.append((cx, cy))
         bboxes.append(bbox)
+        vcols.append(vcol)
         if step.get("name"):
-            # A structure that ends a row gets a vertical arrow out of its bottom;
+            # A structure that ends a row emits a vertical arrow from its bottom;
             # put its name ABOVE so the label never sits on that arrow.
-            vertical_source = (i % cols == cols - 1) and (i < len(built) - 1)
+            vertical_source = (i % cols == cols - 1) and (i < n - 1)
             name_y = cy - bbox[1] - 22 if vertical_source else cy + bbox[1] + 34
-            t = ET.SubElement(page, "t", {"id": str(new_obj()),
-                                          "p": f"{cx} {name_y}", "Justification": "Center"})
-            ET.SubElement(t, "s", {"font": "21", "size": "10", "color": "0",
-                                   "face": "0"}).text = step["name"]
+            add_text(cx, name_y, step["name"], 10, "Center")
 
     # Arrows + conditions between consecutive structures.
-    for i in range(len(steps) - 1):
+    for i in range(n - 1):
         (ax, ay), (bx, by) = centers[i], centers[i + 1]
         (ahw, ahh), (bhw, bhh) = bboxes[i], bboxes[i + 1]
         cond = steps[i + 1].get("conditions", [])
         arrow_id = new_obj()
         if abs(ay - by) < 1.0:          # same row -> horizontal arrow in the gap
-            if bx > ax:                 # pointing right
+            if bx > ax:
                 tail_x, head_x = ax + ahw + ARROW_GAP, bx - bhw - ARROW_GAP
             else:                       # snake row: pointing left
                 tail_x, head_x = ax - ahw - ARROW_GAP, bx + bhw + ARROW_GAP
@@ -166,11 +215,7 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
                 "Head3D": f"{head_x} {ay} 0", "Tail3D": f"{tail_x} {ay} 0"})
             mid_x = (tail_x + head_x) / 2
             for k, line in enumerate(cond):
-                t = ET.SubElement(page, "t", {"id": str(new_obj()),
-                                              "p": f"{mid_x} {ay - COND_DY - 14 * (len(cond) - 1 - k)}",
-                                              "Justification": "Center"})
-                ET.SubElement(t, "s", {"font": "21", "size": "9", "color": "0",
-                                       "face": "0"}).text = line
+                add_text(mid_x, ay - COND_DY - 14 * (len(cond) - 1 - k), _symbolize(line), 9, "Center")
         else:                           # row change -> vertical arrow (same column)
             tail_y, head_y = ay + ahh + ARROW_GAP, by - bhh - ARROW_GAP
             ET.SubElement(page, "arrow", {
@@ -178,12 +223,14 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
                 "ArrowheadHead": "Full", "HeadSize": "1500",
                 "Head3D": f"{ax} {head_y} 0", "Tail3D": f"{ax} {tail_y} 0"})
             mid_y = (tail_y + head_y) / 2
+            # Put conditions on the side toward the page center so a long reagent
+            # name never runs off the right (or left) edge of the canvas.
+            if vcols[i] > (cols - 1) / 2:
+                xt, just = ax - 16, "Right"
+            else:
+                xt, just = ax + 16, "Left"
             for k, line in enumerate(cond):
-                t = ET.SubElement(page, "t", {"id": str(new_obj()),
-                                              "p": f"{ax + 16} {mid_y - 7 + 14 * k}",
-                                              "Justification": "Left"})
-                ET.SubElement(t, "s", {"font": "21", "size": "9", "color": "0",
-                                       "face": "0"}).text = line
+                add_text(xt, mid_y - 7 + 14 * k, _symbolize(line), 9, just)
         # Wire the reaction step (ids only; geometry lives on the page objects).
         ET.SubElement(scheme, "step", {
             "id": str(new_obj()),
@@ -192,9 +239,7 @@ def build_scheme(steps, out_cdxml, out_png=None, title=None, cols=4):
             "ReactionStepArrows": str(arrow_id)})
 
     if title:
-        t = ET.SubElement(page, "t", {"id": str(new_obj()),
-                                      "p": f"{MARGIN} {MARGIN - 34}", "Justification": "Left"})
-        ET.SubElement(t, "s", {"font": "21", "size": "16", "color": "0", "face": "1"}).text = title
+        add_text(MARGIN, MARGIN - 34, title, 16, "Left", bold=True)
 
     cdxml = ET.tostring(root, encoding="unicode")
     # Fail loudly on malformed XML instead of writing a file ChemDraw would reject.

--- a/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/check_scheme.py
+++ b/skills/structural-biology-drug-discovery/rdkit-chemdraw-cdxml/scripts/check_scheme.py
@@ -47,6 +47,8 @@ ON_ARROW = 10.0                      # text-anchor-to-arrow-line distance that r
 CHAR_W = 5.5                         # approx width of one size-9 character (units)
 # Decorative stereo flags to keep out of schemes — draw wedge bonds instead.
 FLAG_WORDS = {"chiral", "achiral", "racemic", "(+/-)", "(±)", "meso"}
+# Non-ASCII characters intentionally allowed in text (degree, delta for heat).
+ALLOWED_NONASCII = {"°", "Δ", "∆"}
 
 
 def _atoms(frag):
@@ -213,11 +215,9 @@ def geometry_check(cdxml_path, perspective_ids=()):
         s = "".join(x.text or "" for x in t.iter("s"))
         if s.strip().lower() in FLAG_WORDS:
             problems.append(f"decorative flag text '{s.strip()}' — remove it; show stereo with wedge bonds")
-        try:
-            s.encode("ascii")
-        except UnicodeEncodeError:
-            bad = [ch for ch in s if ord(ch) > 127]
-            problems.append(f"text '{s[:25]}' has non-ASCII {bad} (font table is iso-8859-1)")
+        bad = [ch for ch in s if ord(ch) > 127 and ch not in ALLOWED_NONASCII]
+        if bad:
+            problems.append(f"text '{s[:25]}' has unsupported non-ASCII {bad} (font table is iso-8859-1)")
         if t.get("p"):
             tx, ty = map(float, t.get("p").split())
             for p0, p1 in arrow_segs:                       # text anchor sitting on an arrow line


### PR DESCRIPTION
## Summary

Follow-up polish to `rdkit-chemdraw-cdxml`, driven by feedback on a rendered scheme (content crowded to the right, clipped reagent text, no sub/superscripts, `0 C`/`heat` instead of `0 °C`/`Δ`) and a script-not-found error in an agent run.

### `build_reaction_scheme.py`
- **Per-row heights** — each row is sized to its own tallest structure, not the global max, so rows of small molecules stop sitting in tall cells with a big empty band.
- **Spread a partial last row** across the full width (transition structure stays aligned under its vertical arrow) so it no longer leaves a column gaping empty.
- **Vertical-arrow conditions toward the page centre** so a long reagent name (`+ N-methylmaleimide`) no longer runs off the canvas edge.
- **Subscripts** for chemical formulas (`BH3`, `H2O2`, `C6H4…`) via `face=32`. Charges stay **inline** (`H+`, `OH-`) — Indigo renders a standalone `+` as a big reaction-plus and mangles superscript (`face=64`), and Arial has no Unicode sub/superscript glyphs, so a raised charge is not achievable in the preview.
- **`_symbolize`**: `"<n> C"` → `"<n> °C"`, the word `"heat"` → `"Δ"` (both render with the Arial font table).

### `check_scheme.py`
- Allow `°`, `Δ`, `∆` through the non-ASCII check (still flags other non-Latin-1 characters).

### `SKILL.md`
- **Fix the helper-copy instructions** (root cause of the agent's `ModuleNotFoundError`/`FileNotFoundError`): the `/SciAgent-Skills/...` path is reachable only via the read-file **tool**, not Python `open()`/`import`. Read each script with the tool, write it into the workdir, then import.
- Update Module 7 + Best Practice # 6 (°C/Δ render; charges inline; subscripts via `face=32`); add Troubleshooting rows for the copy error and the giant-`+` charge.

## Test plan

- [x] `pixi run test` — full suite passes (4120)
- [x] 5-step Diels-Alder scheme renders with `0 °C`, `Δ`, subscripted `BH3`/`H2O2`, inline `H+`, no clipped text, filled bottom-left; `check_scheme` reports 0 problems

Merge, then re-point the hyperlab-agent submodule bump (PR #421) to the new `SciAgent-Skills` main SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)