### PR TITLE
[HL-727][Agent][Skills]분석SKILL에 플랏그리기는 독립적 plot관련 SKILL(omics-plotting)으로 안내

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1591,7 +1591,7 @@ entries:
     sub_type: guide
     category: "data-visualization"
     path: "skills/data-visualization/omics-plotting/SKILL.md"
-    description: "omics-plotting publication-style figure authoring for omics/bioinformatics results with matplotlib/seaborn. Draws a single plot from analysis results or a data table — volcano, MA, expression/correlation heatmap, GSEA bar/dot plot, box/violin/bar/ridgeline, PCA/UMAP/t-SNE, Kaplan-Meier. Supplies a shared journal-ready style and copy-paste recipes so every figure looks like one consistent system. For combining several plots into ONE multi-panel composite figure use multipanel."
+    description: "omics-plotting: publication-style figure authoring for omics/bioinformatics results with matplotlib/seaborn. Read before writing any plotting/figure code in any omics analysis (RNA-seq, proteomics, single-cell, variant, database results) — not only when a plot is explicitly requested. Covers volcano, MA, expression/correlation heatmap, GSEA bar/dot plot, box/violin/bar/ridgeline, PCA/UMAP/t-SNE scatter, Kaplan-Meier, Manhattan/QQ/forest. Supplies a shared journal-ready style and copy-paste recipes so every figure looks like one consistent system. For combining several plots into ONE multi-panel composite figure use multipanel."
     date_added: "2026-08-13"
 
   - name: "multipanel"

--- a/skills/data-visualization/multipanel/SKILL.md
+++ b/skills/data-visualization/multipanel/SKILL.md
@@ -154,9 +154,9 @@ Layout: sketch the grid [[...]], nest subfigures for spanning panels, fill every
    subfigure axis and a standalone figure), build the subfigures (nest for spanning
    panels), call each `draw_<letter>` onto its axis (data) or `imshow` the image,
    collect the subfigures into a `panels` dict, and add panel letters with the helper.
-   Then **always save both outputs** to **workspace-relative** paths under `plots/`:
-   - the **composite** as `plots/combined_figure1.pdf` + `plots/combined_figure1.png`, and
-   - **each individual panel** as `plots/figure1A.png`, `plots/figure1B.png`, … (plus
+   Then **always save both outputs** to **workspace-relative** paths under `figures/`:
+   - the **composite** as `figures/combined_figure1.pdf` + `figures/combined_figure1.png`, and
+   - **each individual panel** as `figures/figure1A.png`, `figures/figure1B.png`, … (plus
      matching `.pdf`) by rendering every `draw_<letter>` onto a fresh standalone figure.
    See "Exporting individual panels" for the exact loop.
 5. **Report the saved paths** back to the user — the combined figure and every
@@ -330,22 +330,22 @@ panels = {"A": sfs[0, 0], "B": sfs[0, 1], "C": top[1]}
 for letter, sf in panels.items():
     DATA_PANELS[letter](sf.subplots())
 add_panel_labels(panels)
-fig.savefig("plots/combined_figure1.pdf")
-fig.savefig("plots/combined_figure1.png", dpi=300)
+fig.savefig("figures/combined_figure1.pdf")
+fig.savefig("figures/combined_figure1.png", dpi=300)
 
 # 3) Individual panels — same functions onto fresh standalone figures (no letter).
 for letter, draw in DATA_PANELS.items():
     w_mm, h_mm = PANEL_SIZE_MM[letter]
     fp = plt.figure(layout="constrained", figsize=(w_mm / 25.4, h_mm / 25.4))
     draw(fp.subplots())
-    fp.savefig(f"plots/figure1{letter}.pdf")
-    fp.savefig(f"plots/figure1{letter}.png", dpi=300)
+    fp.savefig(f"figures/figure1{letter}.pdf")
+    fp.savefig(f"figures/figure1{letter}.png", dpi=300)
     plt.close(fp)
 ```
 
 Output files (Figure 1 with panels A, B, C):
-`plots/combined_figure1.pdf`, `plots/combined_figure1.png`,
-`plots/figure1A.{pdf,png}`, `plots/figure1B.{pdf,png}`, `plots/figure1C.{pdf,png}`.
+`figures/combined_figure1.pdf`, `figures/combined_figure1.png`,
+`figures/figure1A.{pdf,png}`, `figures/figure1B.{pdf,png}`, `figures/figure1C.{pdf,png}`.
 
 Notes:
 - **No panel letter on standalones** — the `A/B/C` label belongs to the composite
@@ -363,11 +363,11 @@ Notes:
 
 - **One figure, one style.** Never stitch separate PNGs or call standalone plot
   functions for a composite; copy their bodies onto each subfigure's axis.
-- **Workspace-relative paths only.** Save under `plots/` (create it if needed);
+- **Workspace-relative paths only.** Save under `figures/` (create it if needed);
   never absolute paths like `/tmp` or `/home/...`.
 - **Only plot data that exists.** Never invent columns, groups, or values.
 - **Label every axis, keep every legend inside its panel, fill every cell.**
-- **Always export both** a vector `.pdf` and a `.png` (dpi≥300) under `plots/`.
+- **Always export both** a vector `.pdf` and a `.png` (dpi≥300) under `figures/`.
 
 ## Common Pitfalls
 

--- a/skills/data-visualization/omics-plotting/SKILL.md
+++ b/skills/data-visualization/omics-plotting/SKILL.md
@@ -3,8 +3,8 @@ name: omics-plotting
 description: >
   Publication-style figure authoring for omics / bioinformatics results. Use
   whenever the user asks for a (single) plot, figure, or chart from analysis
-  results or a data table — volcano, MA, expression / correlation heatmap,
-  GSEA bar / dot plot, box / violin / bar / ridgeline, PCA / UMAP / t-SNE, Kaplan–Meier.
+  results or a data table — volcano, MA, (expression / correlation) heatmap,
+  GSEA bar / dot plot, box / violin / bar / ridgeline, (PCA / UMAP / t-SNE) scatter, Kaplan–Meier.
   The figures are drawn with matplotlib / seaborn; this skill
   supplies the shared style and copy-paste recipes so every figure looks like one
   consistent, journal-ready system. To combine several plots into ONE multi-panel
@@ -113,9 +113,9 @@ What does the table hold?
    below). If the required columns are unclear, inspect the table's header first.
 2. **Write one python script**: paste the style block, load the data,
    draw the plot with the matching recipe, and save to a **workspace-relative**
-   path under `plots/`.
+   path under `figures/`.
 3. **Report the saved path** back to the user (and reference it in any report /
-   deck by that relative path, e.g. `![Volcano](plots/volcano.png)`).
+   deck by that relative path, e.g. `![Volcano](figures/volcano.png)`).
 
 ## Shared style — paste at the top of every plot script
 
@@ -142,6 +142,7 @@ plt.rcParams.update(PUB_STYLE)   # or: with plt.rc_context(PUB_STYLE): ...
 UP, DOWN, NS = "#d73721", "#204897", "#d9d9d9"   # up / down / not-significant
 PALETTE = ["#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4",
            "#008300", "#4a3aa7", "#e34948", "#12a4c0", "#a66a2e"]  # categorical (CVD-safe order)
+GROUP_COLORS = {"Group1": "#204897", "Group2": "#1baf7a", "Group3": "#E7B800"}
 DIVERGING_CMAP = "RdBu_r"    # z-score / log2FC heatmaps — set center=0, vmin=-vmax
 SEQUENTIAL_CMAP = "viridis"  # magnitude / -log10 p / density
 ```
@@ -174,11 +175,14 @@ the column-name variables to match the actual table.
 | Ridgeline | long-form | numeric `x`, categorical `group` |
 | PCA / UMAP / t-SNE | samples × features | numeric features + optional `group` |
 | Kaplan–Meier | survival table | `time`, `event`, `group` |
+| Manhattan | GWAS summary stats | `CHR`, `BP`, `P` |
+| QQ plot | p-value vector | `P` |
+| Forest | effect + CI table | `label`, `estimate`, `ci_low`, `ci_high` |
 
 ## Recipes
 
 Each is a full python script body. Adjust column names, thresholds, and the
-save path. All save under `plots/`.
+save path. All save under `figures/`.
 
 **Volcano** (`-log10 p` vs `log2` fold change):
 
@@ -210,7 +214,24 @@ except ImportError:                             # no adjustText -> label fewer, 
                     fontsize=7, ha="left", va="bottom")
 ax.set_xlabel(r"$\log_{2}$ fold change"); ax.set_ylabel(r"$-\log_{10}$ padj")
 ax.set_title("Volcano plot"); ax.legend(loc="upper right", markerscale=1.4)
-fig.tight_layout(); fig.savefig("plots/volcano.png")
+fig.tight_layout(); fig.savefig("figures/volcano.png")
+```
+
+**MA plot** (`log2` fold change vs mean expression; columns `baseMean`, `log2FoldChange`, optional `padj`):
+
+```python
+import numpy as np, pandas as pd
+df = pd.read_csv("deg_results.csv").dropna(subset=["baseMean", "log2FoldChange"])
+x = np.log10(df["baseMean"].to_numpy(float) + 1)
+fc = df["log2FoldChange"].to_numpy(float)
+sig = (df["padj"].to_numpy(float) < 0.05) if "padj" in df else np.zeros(len(df), bool)
+fig, ax = plt.subplots(figsize=(7, 5))
+ax.scatter(x[~sig], fc[~sig], c=NS, s=10, alpha=0.5, edgecolors="none", rasterized=True, label="NS")
+ax.scatter(x[sig], fc[sig], c=UP, s=14, alpha=0.85, edgecolors="none", label=f"padj<0.05 ({int(sig.sum())})")
+ax.axhline(0, color="0.4", lw=0.8)
+ax.set_xlabel(r"$\log_{10}$(mean norm. count + 1)"); ax.set_ylabel(r"$\log_{2}$ fold change")
+ax.set_title("MA plot"); ax.legend(loc="upper right")
+fig.tight_layout(); fig.savefig("figures/ma.png")
 ```
 
 **Clustered expression heatmap** (z-scored, seaborn `clustermap`):
@@ -222,7 +243,7 @@ g = sns.clustermap(mat, z_score=0, cmap=DIVERGING_CMAP, center=0,
                    figsize=(8, 8), xticklabels=True, yticklabels=mat.shape[0] <= 60,
                    cbar_kws={"label": "z-score"})
 g.ax_col_dendrogram.set_title("Expression heatmap", pad=12)
-g.figure.savefig("plots/heatmap.png")
+g.figure.savefig("figures/heatmap.png")
 ```
 
 **Correlation heatmap** (sample QC):
@@ -233,9 +254,13 @@ corr = pd.read_csv("expr.csv", index_col=0).select_dtypes("number").corr(method=
 mask = np.triu(np.ones_like(corr, dtype=bool), k=1)
 fig, ax = plt.subplots(figsize=(7, 6))
 sns.heatmap(corr, mask=mask, cmap=DIVERGING_CMAP, vmin=-1, vmax=1, center=0,
-            annot=True, fmt=".2f", annot_kws={"size": 7}, square=True,
-            linewidths=0.5, cbar_kws={"label": "Pearson r", "shrink": 0.7}, ax=ax)
-ax.set_title("Sample correlation"); fig.tight_layout(); fig.savefig("plots/corr.png")
+            annot=True, # if the n>20 samples then set annot=False
+            fmt=".2f", annot_kws={"size": 7}, square=True,
+            linewidths=0.5, 
+            cbar_kws={"label": "Pearson r", "shrink": 0.7}, 
+            ax=ax)
+ax.set_title("Sample correlation"); fig.tight_layout(); fig.savefig("figures/corr.png")
+
 ```
 
 **GSEA bar** (top gene sets, colored by direction):
@@ -248,7 +273,7 @@ colors = [UP if v >= 0 else DOWN for v in df["NES"]]
 fig, ax = plt.subplots(figsize=(7, 6))
 ax.barh(df["Term"].astype(str), df["NES"], color=colors)
 ax.axvline(0, color="0.4", lw=0.8); ax.set_xlabel("NES"); ax.set_title("GSEA")
-fig.tight_layout(); fig.savefig("plots/gsea_bar.png")
+fig.tight_layout(); fig.savefig("figures/gsea_bar.png")
 ```
 
 **GSEA dot plot** (clusterProfiler-style; `GeneRatio` may be `"k/n"`):
@@ -267,7 +292,7 @@ fig, ax = plt.subplots(figsize=(7, 6))
 ax.scatter(df["_ratio"], df["Term"].astype(str), s=sizes, c=df["_nlp"], cmap=SEQUENTIAL_CMAP, norm=norm, edgecolors="0.3", linewidths=0.5, zorder=3)
 ax.grid(axis="y", ls=":", color="0.8", zorder=0); ax.set_xlabel("Gene ratio"); ax.set_title("Enrichment")
 cb = fig.colorbar(ScalarMappable(norm=norm, cmap=SEQUENTIAL_CMAP), ax=ax, shrink=0.6, pad=0.02)
-cb.set_label(r"$-\log_{10}$ adj. $p$"); fig.tight_layout(); fig.savefig("plots/dotplot.png")
+cb.set_label(r"$-\log_{10}$ adj. $p$"); fig.tight_layout(); fig.savefig("figures/dotplot.png")
 ```
 
 **Box plot** (long-form, jittered points, optional 2-group test):
@@ -287,34 +312,68 @@ if len(lv) == 2:  # optional significance star
     ymax = df[y].max(); h = (ymax - df[y].min()) * 0.08
     ax.plot([0, 0, 1, 1], [ymax + h, ymax + 2*h, ymax + 2*h, ymax + h], lw=1.0, c="0.2")
     ax.text(0.5, ymax + 2*h, star, ha="center", va="bottom")
-ax.set_title(f"{y} by {x}"); fig.tight_layout(); fig.savefig("plots/box.png")
+ax.set_title(f"{y} by {x}"); fig.tight_layout(); fig.savefig("figures/box.png")
 ```
 
 For **violin** swap `sns.boxplot` → `sns.violinplot(..., inner="box", cut=0)`;
 for **bar of the mean** use `sns.barplot(..., errorbar="se", capsize=0.15)`.
 
-**PCA** (samples × features + `group` column):
+**Grouped embedding scatter (PCA / UMAP / t-SNE / factor scatter):** (samples × features + `group` column):
 
 ```python
-import pandas as pd
-from sklearn.decomposition import PCA
-df = pd.read_csv("samples_features.csv"); grp = df.pop("group") if "group" in df else None
-X = df.select_dtypes("number"); pcs = PCA(n_components=2).fit(X)
-emb = pcs.transform(X); ev = pcs.explained_variance_ratio_ * 100
-fig, ax = plt.subplots(figsize=(6, 5))
-if grp is None:
-    ax.scatter(emb[:, 0], emb[:, 1], s=18, edgecolors="none")
-else:
-    for i, g in enumerate(sorted(grp.unique())):
+import numpy as np, pandas as pd
+
+def scatter_emb(ax, emb, grp, xi=0, yi=1, ev=None, name="PC", centered=True):
+    """emb: (n_samples, n_comp). ev: variance explained % or None. UMAP/t-SNE -> centered=False."""
+    emb, grp = np.asarray(emb), pd.Series(grp).astype(str)
+    for g in [g for g in GROUP_COLORS if g in set(grp)]:     
         m = (grp == g).to_numpy()
-        ax.scatter(emb[m, 0], emb[m, 1], s=18, color=PALETTE[i % len(PALETTE)], edgecolors="none", label=str(g))
-    ax.legend(title=grp.name)
-ax.set_xlabel(f"PC1 ({ev[0]:.1f}%)"); ax.set_ylabel(f"PC2 ({ev[1]:.1f}%)")
-ax.set_title("PCA"); fig.tight_layout(); fig.savefig("plots/pca.png")
+        ax.scatter(emb[m, xi], emb[m, yi], c=GROUP_COLORS[g], s=45, alpha=.9,
+                   edgecolors="white", linewidths=.4, label=g)
+    if centered:                   # PC/factor are 0-centered and equally spaced
+        ax.axhline(0, lw=.5, ls="--", c="0.75"); ax.axvline(0, lw=.5, ls="--", c="0.75")
+        ax.set_aspect("equal", adjustable="datalim")
+    lab = lambda i: f"{name}{i+1}" + (f" ({ev[i]:.1f}%)" if ev is not None else "")
+    ax.set_xlabel(lab(xi)); ax.set_ylabel(lab(yi))
+    ax.spines[["top", "right"]].set_visible(False); ax.legend(frameon=False, fontsize=7)
+```
+FOR **PCA**: samples × features + 'group' column 
+
+``` python
+from sklearn.decomposition import PCA
+
+df = pd.read_csv("samples_features.csv", index_col=0)    
+grp = df.pop("group") if "group" in df else pd.Series("all", index=df.index)
+X = df.select_dtypes("number")
+p = PCA(n_components=min(5, *X.shape)).fit(X) 
+emb, ev = p.transform(X), p.explained_variance_ratio_ * 100
+fig, ax = plt.subplots(figsize=(70/25.4, 70/25.4), constrained_layout=True)
+scatter_emb(ax, emb, grp, 0, 1, ev, "PC")
+fig.savefig("figures/pca.png", dpi=400)
 ```
 
-For **UMAP** use `umap.UMAP(n_neighbors=15, min_dist=0.1)`; for **t-SNE** use
-`sklearn.manifold.TSNE(perplexity=30)` — same scatter styling.
+FOR **UMAP/t-SNE**: no ev
+
+```python
+import umap           # t-SNE: from sklearn.manifold import TSNE
+
+emb = umap.UMAP(n_neighbors=15, min_dist=0.1).fit_transform(X)   # TSNE(perplexity=30).fit_transform(X)
+fig, ax = plt.subplots(figsize=(70/25.4, 70/25.4), constrained_layout=True)
+scatter_emb(ax, emb, grp, name="UMAP", centered=False)    # 원점·축 스케일에 의미 없음
+fig.savefig("figures/umap.png", dpi=400)
+```
+
+FOR **factor scatter**:
+
+```python
+Z  = pd.DataFrame(model.get_factors()["group1"], index=meta.index)
+r2 = model.get_variance_explained()["r2_per_factor"]["group1"]    # view × factor
+ev = r2.sum(axis=0).to_numpy()                           
+keep = [i for i, v in enumerate(ev) if v >= 5.0]        
+fig, ax = plt.subplots(figsize=(70/25.4, 70/25.4), constrained_layout=True)
+scatter_emb(ax, Z, meta["condition"], keep[0], keep[1], ev, "Factor")
+fig.savefig("figures/factor_scatter.png", dpi=400)
+```
 
 **Kaplan–Meier** (survival by group):
 
@@ -328,14 +387,73 @@ for i, g in enumerate(sorted(df["group"].unique())):
     kmf.fit(df.loc[m, "time"], df.loc[m, "event"], label=str(g))
     kmf.plot_survival_function(ax=ax, color=PALETTE[i % len(PALETTE)], ci_show=True)
 ax.set_xlabel("Time"); ax.set_ylabel("Survival probability"); ax.set_ylim(0, 1.02)
-ax.set_title("Kaplan–Meier"); fig.tight_layout(); fig.savefig("plots/km.png")
+ax.set_title("Kaplan–Meier"); fig.tight_layout(); fig.savefig("figures/km.png")
+```
+
+**Manhattan** (GWAS summary stats; columns `CHR`, `BP`, `P`):
+
+```python
+import numpy as np, pandas as pd
+df = pd.read_csv("gwas.csv").dropna(subset=["CHR", "BP", "P"]).copy()
+df["CHR"] = df["CHR"].astype(str)
+chrom_order = sorted(df["CHR"].unique(), key=lambda c: (len(c), c))
+df["_nlp"] = -np.log10(np.clip(df["P"].astype(float), 1e-300, None))
+offset, xticks, ticklabels, xpos = 0.0, [], [], np.zeros(len(df))  # lay chromosomes end-to-end
+for c in chrom_order:
+    m = (df["CHR"] == c).to_numpy()
+    bp = df.loc[m, "BP"].astype(float)
+    xpos[m] = bp + offset
+    xticks.append(offset + bp.median()); ticklabels.append(c)
+    offset = xpos[m].max() + 1
+fig, ax = plt.subplots(figsize=(180/25.4, 70/25.4), constrained_layout=True)
+for i, c in enumerate(chrom_order):
+    m = (df["CHR"] == c).to_numpy()
+    ax.scatter(xpos[m], df["_nlp"].to_numpy()[m], s=6, c=["#2a78d6", "#9fb3c8"][i % 2], edgecolors="none")
+ax.axhline(-np.log10(5e-8), color=UP, lw=0.8, ls="--")   # genome-wide significance
+ax.set_xticks(xticks); ax.set_xticklabels(ticklabels, fontsize=6)
+ax.set_xlabel("Chromosome"); ax.set_ylabel(r"$-\log_{10} p$"); ax.set_title("Manhattan")
+fig.savefig("figures/manhattan.png", dpi=400)
+```
+
+**QQ plot** (p-value calibration; reports genomic inflation λ):
+
+```python
+import numpy as np, pandas as pd
+from scipy import stats
+p = pd.read_csv("gwas.csv")["P"].dropna().astype(float).to_numpy()
+p = np.clip(np.sort(p), 1e-300, 1.0)
+obs = -np.log10(p)
+exp = -np.log10((np.arange(1, len(p) + 1) - 0.5) / len(p))
+lam = np.median(stats.chi2.isf(p, 1)) / stats.chi2.isf(0.5, 1)   # genomic inflation
+fig, ax = plt.subplots(figsize=(70/25.4, 70/25.4), constrained_layout=True)
+ax.scatter(exp, obs, s=6, c="#2a78d6", edgecolors="none")
+lim = float(max(exp.max(), obs.max()))
+ax.plot([0, lim], [0, lim], color="0.4", lw=0.8, ls="--")
+ax.set_xlabel(r"Expected $-\log_{10} p$"); ax.set_ylabel(r"Observed $-\log_{10} p$")
+ax.set_title(f"QQ (λ = {lam:.3f})"); fig.savefig("figures/qq.png", dpi=400)
+```
+
+**Forest** (effect size ± 95% CI per study/variant; columns `label`, `estimate`, `ci_low`, `ci_high`):
+
+```python
+import pandas as pd
+df = pd.read_csv("effects.csv").iloc[::-1].reset_index(drop=True)  # first row at top
+y = list(range(len(df)))
+fig, ax = plt.subplots(figsize=(90/25.4, max(60, 14 * len(df)) / 25.4), constrained_layout=True)
+ax.errorbar(df["estimate"], y,
+            xerr=[df["estimate"] - df["ci_low"], df["ci_high"] - df["estimate"]],
+            fmt="s", color="#204897", ecolor="0.4", capsize=2, markersize=4, lw=0.8)
+ax.axvline(1.0, color=UP, lw=0.8, ls="--")   # null: OR/HR=1 (use 0.0 for log-scale beta)
+ax.set_yticks(y); ax.set_yticklabels(df["label"])
+ax.set_xlabel("Effect size (95% CI)"); ax.set_title("Forest")
+fig.savefig("figures/forest.png", dpi=400)
 ```
 
 ## Best Practices
 
 - **Only plot data that exists.** Never invent columns, groups, or values; if a
   needed column is missing, inspect the header and ask or adapt — do not fabricate.
-- **Workspace-relative paths only.** Save under `plots/` (create it if needed);
+- **Workspace-relative paths only.** Save under `figures/` (create it if needed);
   never write to absolute paths like `/tmp` or `/home/...`.
 - **Reuse the palette across a figure set** so related panels share colors for
   the same group / direction. Use the diverging colormap (centered at 0) for
@@ -343,7 +461,7 @@ ax.set_title("Kaplan–Meier"); fig.tight_layout(); fig.savefig("plots/km.png")
   However, if the user explicitly requests a different color, use it.
 - **Label axes and give a real title.** Include units, group `n`, and thresholds
   where relevant (e.g. volcano cutoff lines).
-- For vector / print output, also save a `.pdf` (`fig.savefig("plots/x.pdf")`);
+- For vector / print output, also save a `.pdf` (`fig.savefig("figures/x.pdf")`);
   text stays editable because `pdf.fonttype=42` / `svg.fonttype="none"`.
 
 ## Common Pitfalls

--- a/skills/data-visualization/omics-plotting/SKILL.md
+++ b/skills/data-visualization/omics-plotting/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: omics-plotting
 description: >
-  Publication-style figure authoring for omics / bioinformatics results. Use
-  whenever the user asks for a (single) plot, figure, or chart from analysis
-  results or a data table — volcano, MA, (expression / correlation) heatmap,
-  GSEA bar / dot plot, box / violin / bar / ridgeline, (PCA / UMAP / t-SNE) scatter, Kaplan–Meier.
-  The figures are drawn with matplotlib / seaborn; this skill
-  supplies the shared style and copy-paste recipes so every figure looks like one
-  consistent, journal-ready system. To combine several plots into ONE multi-panel
-  composite figure, use the sibling `multipanel` skill.
+  omics-plotting: publication-style figure authoring for omics / bioinformatics
+  results with matplotlib / seaborn. Read this before writing any plotting or
+  figure code in any omics analysis — RNA-seq, proteomics, single-cell, variant,
+  or database results — not only when a plot is explicitly requested: whenever an
+  analysis will produce a figure, load this first and follow its recipes. Covers
+  volcano, MA, expression / correlation heatmap, GSEA bar / dot plot,
+  box / violin / bar / ridgeline, PCA / UMAP / t-SNE scatter, Kaplan–Meier,
+  Manhattan / QQ / forest. Supplies a shared journal-ready style and copy-paste
+  recipes so every figure looks like one consistent system. To combine several
+  plots into ONE multi-panel composite figure, use the sibling `multipanel` skill.
 license: Proprietary (HITS Inc.)
 ---
 
@@ -142,7 +144,7 @@ plt.rcParams.update(PUB_STYLE)   # or: with plt.rc_context(PUB_STYLE): ...
 UP, DOWN, NS = "#d73721", "#204897", "#d9d9d9"   # up / down / not-significant
 PALETTE = ["#2a78d6", "#eb6834", "#1baf7a", "#eda100", "#e87ba4",
            "#008300", "#4a3aa7", "#e34948", "#12a4c0", "#a66a2e"]  # categorical (CVD-safe order)
-GROUP_COLORS = {"Group1": "#204897", "Group2": "#1baf7a", "Group3": "#E7B800"}
+GROUP_COLORS = {"Group1": "#204897", "Group2": "#e34948", "Group3": "#E7B800"}
 DIVERGING_CMAP = "RdBu_r"    # z-score / log2FC heatmaps — set center=0, vmin=-vmax
 SEQUENTIAL_CMAP = "viridis"  # magnitude / -log10 p / density
 ```

--- a/skills/genomics-bioinformatics/databases/archs4-database/SKILL.md
+++ b/skills/genomics-bioinformatics/databases/archs4-database/SKILL.md
@@ -18,6 +18,7 @@ ARCHS4 (All RNA-seq and ChIP-seq Sample and Signature Search) is a resource of u
 - Comparing expression profiles of multiple genes across tissues to prioritize candidates for wet-lab follow-up
 - Accessing uniformly processed gene expression matrices (HDF5 format) for large-scale cross-study analysis
 - Validating differential expression results by checking whether a gene's expression direction matches population-level tissue profiles
+- Use **omics-plotting** SKILL to render bar charts and expression heatmaps from the query results
 - For variant-level population allele frequencies use `gnomad-database`; ARCHS4 provides expression evidence only
 - For Enrichr pathway enrichment from a gene list use `gget-genomic-databases` (`gget enrichr`); ARCHS4 is for expression lookups
 
@@ -240,53 +241,29 @@ for gene in housekeeping:
 
 ### Query 5: Visualization — Tissue Expression Barplot
 
-Generate a publication-ready barplot of z-score expression across the top tissues for a gene.
+Fetch the top-tissue z-scores, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Box / Violin / Bar" recipe** on the exported CSV (→ `figures/BRCA1_tissue_expression.png`).
 
 ```python
 import requests
 import pandas as pd
-import matplotlib.pyplot as plt
 
 ARCHS4_BASE = "https://maayanlab.cloud/archs4/api/v1"
 
-def plot_tissue_expression(gene_symbol: str, top_n: int = 20,
-                            species: str = "human",
-                            output_file: str = None) -> None:
-    """Plot top tissue z-score expression for a gene.
-
-    Parameters
-    ----------
-    gene_symbol : str
-        HGNC gene symbol.
-    top_n : int
-        Number of top tissues to display.
-    species : str
-        'human' or 'mouse'.
-    output_file : str
-        If provided, save figure to this path.
-    """
+def tissue_zscores(gene_symbol: str, top_n: int = 20, species: str = "human") -> pd.DataFrame:
+    """Fetch top tissue z-scores for a gene and save for plotting."""
     r = requests.get(
         f"{ARCHS4_BASE}/meta/genes/{gene_symbol}/zscore",
         params={"species": species},
-        timeout=30
+        timeout=30,
     )
     r.raise_for_status()
-    records = r.json().get("values", [])
-    df = pd.DataFrame(records).sort_values("zscore", ascending=False).head(top_n)
+    df = pd.DataFrame(r.json().get("values", [])).sort_values("zscore", ascending=False).head(top_n)
+    df.to_csv(f"{gene_symbol}_tissue_zscores.csv", index=False)
+    return df
 
-    fig, ax = plt.subplots(figsize=(10, 6))
-    colors = ["#D73027" if z > 0 else "#4575B4" for z in df["zscore"]]
-    bars = ax.barh(df["tissue"][::-1], df["zscore"][::-1], color=colors[::-1])
-    ax.axvline(0, color="black", linewidth=0.8, linestyle="--")
-    ax.set_xlabel("Expression Z-Score")
-    ax.set_title(f"ARCHS4 Tissue Expression: {gene_symbol} ({species})\nTop {top_n} tissues")
-    ax.bar_label(bars, fmt="%.2f", padding=3, fontsize=8)
-    plt.tight_layout()
-    fname = output_file or f"{gene_symbol}_tissue_expression.png"
-    plt.savefig(fname, dpi=150, bbox_inches="tight")
-    print(f"Saved {fname}  ({len(df)} tissues plotted)")
-
-plot_tissue_expression("BRCA1", top_n=15, output_file="BRCA1_tissue_expression.png")
+df = tissue_zscores("BRCA1", top_n=15)
+print(f"Top tissues for BRCA1: {len(df)} -> BRCA1_tissue_zscores.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Box / Violin / Bar" recipe (horizontal bar of zscore by tissue).
 ```
 
 ### Query 6: HDF5 Bulk Data Access
@@ -377,8 +354,6 @@ ARCHS4 indexes human samples using HGNC gene symbols (uppercase, e.g., `TP53`) a
 ```python
 import requests, time
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
 
 ARCHS4_BASE = "https://maayanlab.cloud/archs4/api/v1"
 
@@ -412,25 +387,10 @@ tissue_importance = matrix.abs().max(axis=0).sort_values(ascending=False)
 top_tissues = tissue_importance.head(top_n_tissues).index
 matrix_subset = matrix[top_tissues]
 
-# Plot heatmap
-fig, ax = plt.subplots(figsize=(14, 5))
-sns.heatmap(
-    matrix_subset,
-    cmap="RdBu_r",
-    center=0,
-    vmin=-3,
-    vmax=3,
-    ax=ax,
-    cbar_kws={"label": "Z-Score"},
-    linewidths=0.5
-)
-ax.set_title("ARCHS4 Tissue Expression Profiles — Gene Panel")
-ax.set_xlabel("Tissue")
-ax.set_ylabel("Gene")
-plt.xticks(rotation=45, ha="right", fontsize=8)
-plt.tight_layout()
-plt.savefig("archs4_panel_heatmap.png", dpi=150, bbox_inches="tight")
-print(f"Saved archs4_panel_heatmap.png  ({matrix_subset.shape})")
+# Save the gene × tissue matrix; render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Expression heatmap"
+# recipe (RdBu_r, center=0) -> figures/archs4_panel_heatmap.png
+matrix_subset.to_csv("archs4_panel_matrix.csv")
+print(f"Panel matrix ready: {matrix_subset.shape} -> archs4_panel_matrix.csv")
 ```
 
 ### Workflow 2: Co-expression Network Seed Expansion

--- a/skills/genomics-bioinformatics/databases/cbioportal-database/SKILL.md
+++ b/skills/genomics-bioinformatics/databases/cbioportal-database/SKILL.md
@@ -18,6 +18,7 @@ cBioPortal for Cancer Genomics is a public repository of cancer genomics data in
 - Identifying which cancer studies have molecular profiling data for a specific cancer type (e.g., breast, lung)
 - Downloading gene expression (RNA-seq FPKM/RSEM) data from specific TCGA cohorts for differential expression analysis
 - Correlating genomic alterations with clinical outcomes in a specific study
+- Use **omics-plotting** SKILL to render bar charts, mutation-frequency heatmaps, and Kaplan–Meier curves from the query results
 - Use `gnomad-database` instead when you need population-level variant allele frequencies in healthy individuals
 - For drug-gene interaction lookups use `opentargets-database`; cBioPortal provides the genomic alteration data, not drug interaction annotations
 
@@ -360,12 +361,11 @@ print(gene_df.to_string(index=False))
 
 ### Query 7: Visualization — Mutation Frequency Barplot
 
-Plot mutation frequency across TCGA studies for a cancer driver gene.
+Compute mutation frequency across TCGA studies for a cancer driver gene, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Box / Violin / Bar" recipe** on the exported CSV (→ `figures/TP53_mutation_frequency.png`).
 
 ```python
 import requests, time
 import pandas as pd
-import matplotlib.pyplot as plt
 
 BASE_URL = "https://www.cbioportal.org/api"
 
@@ -413,18 +413,9 @@ for study_id, label in STUDIES.items():
         print(f"  Skipping {study_id}: {e}")
 
 df = pd.DataFrame(rows).sort_values("freq", ascending=True)
-
-fig, ax = plt.subplots(figsize=(7, 4))
-bars = ax.barh(df["study"], df["freq"], color="#C0392B", edgecolor="white")
-ax.bar_label(bars, labels=[f"{v:.0f}%  (n={n})" for v, n in zip(df["freq"], df["n_mutated"])],
-             padding=4, fontsize=9)
-ax.set_xlabel(f"{GENE_SYMBOL} Mutation Frequency (%)")
-ax.set_title(f"{GENE_SYMBOL} Somatic Mutation Frequency\nacross TCGA PanCancer Atlas Studies")
-ax.set_xlim(0, df["freq"].max() * 1.3)
-plt.tight_layout()
-plt.savefig(f"{GENE_SYMBOL}_mutation_frequency.png", dpi=150, bbox_inches="tight")
-print(f"Saved {GENE_SYMBOL}_mutation_frequency.png")
+df.to_csv(f"{GENE_SYMBOL}_mutation_frequency.csv", index=False)
 print(df[["study", "n_mutated", "n_total", "freq"]].to_string(index=False))
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Box / Violin / Bar" recipe (horizontal bar of freq by study).
 ```
 
 ## Key Concepts
@@ -518,8 +509,6 @@ print(f"\nSaved: {study_id}_driver_mutations.csv")
 ```python
 import requests
 import pandas as pd
-import matplotlib.pyplot as plt
-from matplotlib.patches import Patch
 
 BASE_URL = "https://www.cbioportal.org/api"
 
@@ -575,40 +564,14 @@ merged = merged.dropna(subset=["OS_STATUS", "OS_MONTHS"])
 merged["OS_MONTHS"] = pd.to_numeric(merged["OS_MONTHS"], errors="coerce")
 merged["event"] = (merged["OS_STATUS"] == "1:DECEASED").astype(int)
 
-# Simple Kaplan-Meier-style plot (manual step function)
-def km_curve(df, time_col="OS_MONTHS"):
-    times = sorted(df[time_col].dropna().values)
-    surv = []
-    s = 1.0
-    n = len(times)
-    for i, t in enumerate(times):
-        s *= (1 - 1 / (n - i))
-        surv.append((t, s))
-    return surv
-
-fig, ax = plt.subplots(figsize=(8, 5))
-colors = {"Amplified": "#C0392B", "Diploid": "#2980B9"}
-for status, color in colors.items():
-    grp = merged[merged["erbb2_status"] == status]
-    if len(grp) < 10:
-        continue
-    km = km_curve(grp)
-    times = [0] + [x[0] for x in km]
-    surv  = [1.0] + [x[1] for x in km]
-    ax.step(times, surv, where="post", color=color,
-            label=f"ERBB2 {status} (n={len(grp)})", lw=2)
-
-ax.set_xlabel("Overall Survival (months)")
-ax.set_ylabel("Survival Probability")
-ax.set_title("ERBB2 CNA Status vs. Overall Survival\nTCGA BRCA (PanCancer Atlas)")
-ax.legend()
-ax.set_ylim(0, 1.05)
-ax.grid(True, alpha=0.3)
-plt.tight_layout()
-plt.savefig("erbb2_survival.png", dpi=150, bbox_inches="tight")
-print(f"Saved erbb2_survival.png")
-print(f"ERBB2 Amplified: {(merged['erbb2_status']=='Amplified').sum()} samples")
-print(f"ERBB2 Diploid:   {(merged['erbb2_status']=='Diploid').sum()} samples")
+# Survival table for the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Kaplan–Meier" recipe (columns: time, event, group)
+km_input = (merged.loc[merged["erbb2_status"].isin(["Amplified", "Diploid"]),
+                       ["OS_MONTHS", "event", "erbb2_status"]]
+            .rename(columns={"OS_MONTHS": "time", "erbb2_status": "group"}))
+km_input.to_csv("erbb2_survival.csv", index=False)
+print(f"Survival table: {len(km_input)} patients -> erbb2_survival.csv")
+print(km_input["group"].value_counts().to_string())
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Kaplan–Meier" recipe -> figures/erbb2_survival.png
 ```
 
 ### Workflow 3: Multi-Study Alteration Frequency Heatmap
@@ -618,8 +581,6 @@ print(f"ERBB2 Diploid:   {(merged['erbb2_status']=='Diploid').sum()} samples")
 ```python
 import requests, time
 import pandas as pd
-import matplotlib.pyplot as plt
-import numpy as np
 
 BASE_URL = "https://www.cbioportal.org/api"
 
@@ -673,24 +634,10 @@ for study_id, label in STUDIES.items():
         print(f"  {label}: {e}")
 
 freq_matrix = freq_matrix.fillna(0).astype(float)
-
-fig, ax = plt.subplots(figsize=(7, 4))
-im = ax.imshow(freq_matrix.values, cmap="YlOrRd", aspect="auto", vmin=0, vmax=80)
-ax.set_xticks(range(len(freq_matrix.columns)))
-ax.set_xticklabels(freq_matrix.columns, rotation=30, ha="right")
-ax.set_yticks(range(len(freq_matrix.index)))
-ax.set_yticklabels(freq_matrix.index)
-for i in range(len(freq_matrix.index)):
-    for j in range(len(freq_matrix.columns)):
-        val = freq_matrix.iloc[i, j]
-        ax.text(j, i, f"{val:.0f}%", ha="center", va="center", fontsize=9,
-                color="white" if val > 40 else "black")
-plt.colorbar(im, ax=ax, label="Mutation Frequency (%)")
-ax.set_title("Somatic Mutation Frequency — TCGA PanCancer Atlas")
-plt.tight_layout()
-plt.savefig("mutation_frequency_heatmap.png", dpi=150, bbox_inches="tight")
-print("Saved mutation_frequency_heatmap.png")
+freq_matrix.to_csv("mutation_frequency_matrix.csv")
 print(freq_matrix.to_string())
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Expression heatmap" recipe (gene x cancer-type, YlOrRd,
+# annotated) -> figures/mutation_frequency_heatmap.png
 ```
 
 ## Key Parameters

--- a/skills/genomics-bioinformatics/databases/gwas-database/SKILL.md
+++ b/skills/genomics-bioinformatics/databases/gwas-database/SKILL.md
@@ -20,6 +20,7 @@ The NHGRI-EBI GWAS Catalog is a curated collection of published genome-wide asso
 - Identifying published GWAS studies by disease, gene, or PubMed ID
 - Cross-referencing EFO trait ontology terms with GWAS evidence
 - Building candidate gene lists from GWAS association regions
+- Use **omics-plotting** SKILL to render Manhattan, QQ, and forest plots from the summary statistics / association results
 - For **drug target validation from GWAS hits**, use `opentargets-database` instead
 - For **variant functional annotation** (consequence prediction, regulatory impact), use Ensembl VEP via `gget`
 
@@ -409,51 +410,24 @@ for tid, info in sorted(trait_set.items(), key=lambda x: x[1]["best_pval"]):
 
 ```python
 import numpy as np
-import matplotlib.pyplot as plt
-import csv, gzip, io, requests
+import pandas as pd
 
-# Simulated summary statistics for demonstration
-# In practice: download from GWAS Catalog FTP
+# Summary statistics as a CHR/BP/P table (simulated here for demonstration).
+# In practice: download from GWAS Catalog FTP, e.g.
 # url = "http://ftp.ebi.ac.uk/pub/databases/gwas/summary_statistics/GCSTXXXXXX/..."
-# resp = requests.get(url); data = gzip.decompress(resp.content)
-
+# import gzip, requests; data = gzip.decompress(requests.get(url).content)
 np.random.seed(42)
 n_snps = 5000
-chroms = np.random.choice(range(1, 23), size=n_snps)
-positions = np.random.randint(1, 250_000_000, size=n_snps)
 pvalues = np.random.uniform(0, 1, size=n_snps)
-# Add some "hits"
-pvalues[:20] = 10 ** np.random.uniform(-15, -8, size=20)
-
-# Manhattan plot
-log_p = -np.log10(pvalues)
-chrom_offsets = {}
-running_offset = 0
-for c in range(1, 23):
-    chrom_offsets[c] = running_offset
-    running_offset += 250_000_000
-
-x_positions = [positions[i] + chrom_offsets[chroms[i]] for i in range(n_snps)]
-colors = ["#1f77b4" if c % 2 == 0 else "#ff7f0e" for c in chroms]
-
-fig, ax = plt.subplots(figsize=(14, 5))
-ax.scatter(x_positions, log_p, c=colors, s=4, alpha=0.6)
-ax.axhline(y=-np.log10(5e-8), color="red", linestyle="--", linewidth=0.8,
-           label="Genome-wide significance (p=5e-8)")
-ax.axhline(y=-np.log10(1e-5), color="blue", linestyle=":", linewidth=0.5,
-           label="Suggestive (p=1e-5)")
-ax.set_xlabel("Chromosome")
-ax.set_ylabel("-log10(p-value)")
-ax.set_title("GWAS Manhattan Plot")
-ax.legend(fontsize=8)
-
-# Chromosome labels
-tick_positions = [chrom_offsets[c] + 125_000_000 for c in range(1, 23)]
-ax.set_xticks(tick_positions)
-ax.set_xticklabels([str(c) for c in range(1, 23)], fontsize=7)
-plt.tight_layout()
-plt.savefig("manhattan_plot.png", dpi=300, bbox_inches="tight")
-print("Saved manhattan_plot.png")
+pvalues[:20] = 10 ** np.random.uniform(-15, -8, size=20)   # add some "hits"
+sumstats = pd.DataFrame({
+    "CHR": np.random.choice(range(1, 23), size=n_snps),
+    "BP": np.random.randint(1, 250_000_000, size=n_snps),
+    "P": pvalues,
+})
+sumstats.to_csv("gwas.csv", index=False)
+print(f"Summary stats: {len(sumstats)} SNPs, {(sumstats['P'] < 5e-8).sum()} genome-wide sig -> gwas.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Manhattan" recipe -> figures/manhattan_plot.png
 ```
 
 ## Key Parameters
@@ -551,8 +525,8 @@ print(f"Total associations in region: {len(region_assocs)}")
 Visualize effect sizes across studies for a single variant.
 
 ```python
-import matplotlib.pyplot as plt
-import numpy as np
+import re
+import pandas as pd
 import requests, time
 
 BASE = "https://www.ebi.ac.uk/gwas/rest/api"
@@ -561,29 +535,24 @@ data = requests.get(f"{BASE}/singleNucleotidePolymorphisms/rs1801282/association
 time.sleep(0.2)
 assocs = data["_embedded"]["associations"]
 
-# Extract OR values (filter to those with OR data)
-entries = []
+def parse_ci(text):
+    """Pull [low-high] confidence bounds out of the GWAS Catalog 'range' string."""
+    nums = re.findall(r"[0-9]*\.?[0-9]+", text or "")
+    return (float(nums[0]), float(nums[1])) if len(nums) >= 2 else (float("nan"), float("nan"))
+
+# Build a forest-plot table: label, estimate (OR), ci_low, ci_high
+rows = []
 for a in assocs:
     or_val = a.get("orPerCopyNum")
-    ci_text = a.get("range", "")
     trait = a.get("efoTraits", [{}])[0].get("trait", "N/A") if a.get("efoTraits") else "N/A"
     if or_val and or_val > 0:
-        entries.append({"trait": trait[:30], "or": or_val, "ci": ci_text})
+        lo, hi = parse_ci(a.get("range", ""))
+        rows.append({"label": trait[:30], "estimate": or_val, "ci_low": lo, "ci_high": hi})
 
-if entries:
-    fig, ax = plt.subplots(figsize=(8, max(3, len(entries) * 0.4)))
-    y_pos = range(len(entries))
-    ors = [e["or"] for e in entries]
-    labels = [f"{e['trait']} (OR={e['or']:.2f})" for e in entries]
-    ax.barh(y_pos, [np.log(o) for o in ors], color=["#d62728" if o > 1 else "#2ca02c" for o in ors])
-    ax.set_yticks(y_pos)
-    ax.set_yticklabels(labels, fontsize=8)
-    ax.axvline(x=0, color="black", linewidth=0.8)
-    ax.set_xlabel("log(OR)")
-    ax.set_title("rs1801282 (PPARG) Effect Sizes")
-    plt.tight_layout()
-    plt.savefig("forest_plot.png", dpi=300, bbox_inches="tight")
-    print(f"Saved forest_plot.png with {len(entries)} entries")
+effects = pd.DataFrame(rows)
+effects.to_csv("effects.csv", index=False)
+print(f"Effect sizes: {len(effects)} entries -> effects.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Forest" recipe (null line at OR=1) -> figures/forest_plot.png
 ```
 
 ## Troubleshooting

--- a/skills/genomics-bioinformatics/databases/mouse-phenome-database/SKILL.md
+++ b/skills/genomics-bioinformatics/databases/mouse-phenome-database/SKILL.md
@@ -18,6 +18,7 @@ The Mouse Phenome Database (MPD), maintained at the Jackson Laboratory, catalogs
 - Finding MPD projects that measure a trait of interest using ontology terms (MP, VT, MA) or free-text descriptions
 - Validating mouse strain nomenclature (canonical JAX names ↔ stock numbers ↔ MGI IDs) before submitting orders or analyses
 - Looking up coordinates and annotations for mouse genes in the MPD/MGI cross-reference
+- Use **omics-plotting** SKILL to render strain-mean bar charts and strain × measure heatmaps from the query results
 - Use `monarch-database` instead for disease-gene-phenotype knowledge graphs (HPO ↔ MP ↔ disease)
 - Use `ensembl-database` instead for transcript-level mouse gene annotations and variant consequence prediction
 
@@ -316,7 +317,7 @@ Discover the live list any time with `GET /project_filters/mpdsector`.
 **Goal**: From "I want to compare heart rate across inbred strains" → land on real data and produce a ranked barplot.
 
 ```python
-import requests, pandas as pd, matplotlib.pyplot as plt, time
+import requests, pandas as pd, time
 
 MPD = "https://phenome.jax.org/api"
 
@@ -338,18 +339,10 @@ print(f"\nPicked: {projsym} measnum={hr['measnum']} varname={hr['varname']} ({hr
 # 3) Pull strain means, plot male strains ranked
 sm = pd.DataFrame(requests.get(f"{MPD}/pheno/strainmeans/{hr['measnum']}", timeout=30).json()["strainmeans"])
 male = sm[sm["sex"] == "m"].sort_values("mean", ascending=False).reset_index(drop=True)
-
-fig, ax = plt.subplots(figsize=(9, 4))
-bars = ax.bar(male["strain"], male["mean"], yerr=male["sem"],
-              color="#1976D2", capsize=3, edgecolor="white")
-ax.bar_label(bars, fmt="%.0f", padding=3, fontsize=8)
-ax.set_xlabel("Strain")
-ax.set_ylabel(f"Mean {hr['varname']} ({hr['units']})")
-ax.set_title(f"{hr['descrip']} by inbred strain (male) — {projsym}")
-plt.xticks(rotation=30, ha="right")
-plt.tight_layout()
-plt.savefig("mpd_strain_means.png", dpi=150, bbox_inches="tight")
-print("Saved mpd_strain_means.png")
+male.to_csv("mpd_strain_means.csv", index=False)
+print(f"Strain means (male): {len(male)} strains -> mpd_strain_means.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Box / Violin / Bar" recipe (bar of mean by strain,
+# yerr=sem) -> figures/mpd_strain_means.png
 ```
 
 ### Workflow 2: Per-Animal Data → R/qtl2 CSV Export
@@ -380,7 +373,7 @@ print(out.head().to_string(index=False))
 **Goal**: Build a wide-format strain × measure table (z-scored) from one project for comparative visualisation.
 
 ```python
-import requests, pandas as pd, matplotlib.pyplot as plt
+import requests, pandas as pd
 
 MPD = "https://phenome.jax.org/api"
 projsym = "Jaxwest1"
@@ -397,18 +390,9 @@ print(f"Shape: {wide.shape}  (strains × measures)")
 keep = wide.dropna(axis=1, thresh=int(0.8 * len(wide))).columns[:10]
 wide = wide[keep].dropna()
 print(f"After coverage filter: {wide.shape}")
-
-fig, ax = plt.subplots(figsize=(8, max(3, 0.3 * len(wide))))
-im = ax.imshow(wide.values, aspect="auto", cmap="RdBu_r", vmin=-2, vmax=2)
-ax.set_xticks(range(len(wide.columns)))
-ax.set_xticklabels(wide.columns, rotation=45, ha="right", fontsize=8)
-ax.set_yticks(range(len(wide.index)))
-ax.set_yticklabels(wide.index, fontsize=8)
-fig.colorbar(im, ax=ax, label="z-score")
-ax.set_title(f"{projsym} — strain × measure z-score heatmap (male)")
-plt.tight_layout()
-plt.savefig("mpd_strain_measure_heatmap.png", dpi=150, bbox_inches="tight")
-print("Saved mpd_strain_measure_heatmap.png")
+wide.to_csv("mpd_strain_measure_matrix.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Expression heatmap" recipe (strain x measure z-score,
+# RdBu_r, center=0) -> figures/mpd_strain_measure_heatmap.png
 ```
 
 ## Key Parameters

--- a/skills/genomics-bioinformatics/interval-ops/deeptools-ngs-analysis/SKILL.md
+++ b/skills/genomics-bioinformatics/interval-ops/deeptools-ngs-analysis/SKILL.md
@@ -19,6 +19,7 @@ deepTools is a command-line toolkit for processing and visualizing high-throughp
 - Creating heatmaps and profile plots around TSS, peaks, or other genomic regions
 - Analyzing ATAC-seq data with Tn5 offset correction
 - Generating strand-specific RNA-seq coverage tracks
+- Use **omics-plotting** SKILL for custom figures from exported score matrices; standard signal heatmaps/profiles use deeptools' own `plotHeatmap`/`plotProfile`
 - For **read alignment**, use STAR, BWA, or bowtie2 instead
 - For **peak calling**, use MACS2 or HOMER instead
 - For **BAM/VCF file manipulation**, use pysam instead

--- a/skills/genomics-bioinformatics/rnaseq/deseq2-differential-expression/SKILL.md
+++ b/skills/genomics-bioinformatics/rnaseq/deseq2-differential-expression/SKILL.md
@@ -21,7 +21,8 @@ DESeq2 is the Bioconductor R package for differential gene expression analysis f
 - Working in an R/Bioconductor ecosystem where integration with SummarizedExperiment, clusterProfiler, or EnhancedVolcano is needed
 - Use **pydeseq2-differential-expression** instead for Python-based pipelines with the same statistical model
 - Use **edgeR** for negative binomial DE with TMM normalization, quasi-likelihood F-tests, or TREAT testing
-- Use **gseapy-gene-enrichment** after DE to interpret results at the pathway level
+- Use **omics-plotting** SKILL after DE and for publication-quality plots of DESeq2 results
+- Use **gseapy-gene-enrichment** SKILL after DE to interpret results at the pathway level
 
 ## Prerequisites
 
@@ -244,32 +245,13 @@ write.csv(sig_genes, "deseq2_significant.csv")
 ### Step 7: Visualize — MA Plot, Volcano Plot, and Heatmap
 
 > **Compute/viz separation (required):** Do not combine DESeq2 computation and plotting in the same code block. Step 6 (or Step 5) saves the results CSV; this step loads that CSV and produces plots only. This way plots can be regenerated or restyled without re-running the expensive computation.
+> **Plotting:** for the volcano, **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Volcano" recipe** on the exported DEG CSV (→ `figures/volcano_plot.pdf`). The heatmap below stays native R (`pheatmap`).
 
 ```r
-library(EnhancedVolcano)
+# Volcano: use the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Volcano" recipe on the exported DEG CSV -> figures/volcano_plot.pdf
+
 library(pheatmap)
-
-# --- MA Plot (base DESeq2) ---
-plotMA(res_shrunk, ylim = c(-5, 5),
-       main = "MA Plot (apeglm-shrunk LFC)",
-       colSig = "firebrick", colNonSig = "grey60")
-# Blue points are significantly DE genes; y-axis is shrunk log2FC
-
-# --- Volcano Plot (EnhancedVolcano) ---
-EnhancedVolcano(res_shrunk_df,
-    lab        = rownames(res_shrunk_df),
-    x          = "log2FoldChange",
-    y          = "padj",
-    pCutoff    = 0.05,
-    FCcutoff   = 1.0,
-    xlim       = c(-6, 6),
-    title      = "Treated vs. Control",
-    subtitle   = "apeglm-shrunk LFC | BH-adjusted p-value",
-    legendLabels = c("NS", "LFC", "padj", "padj & LFC"))
-
-ggsave("volcano_plot.pdf", width = 8, height = 7)
-
-# --- Heatmap of top 50 DE genes ---
+# ---Heatmap of top 50 DE genes ---
 top50 <- head(rownames(sig_genes[order(sig_genes$padj), ]), 50)
 mat   <- assay(vsd)[top50, ]            # variance-stabilized expression
 mat   <- mat - rowMeans(mat)            # center by gene mean
@@ -279,17 +261,17 @@ annotation_col <- data.frame(
     Batch     = coldata$batch,
     row.names = colnames(mat)
 )
-
+# Use the code in the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) for publication-quality heatmap plots or use below code to generate a heatmap
 pheatmap(mat,
          annotation_col  = annotation_col,
          cluster_rows    = TRUE,
          cluster_cols    = TRUE,
          show_rownames   = TRUE,
          fontsize_row    = 6,
-         filename        = "heatmap_top50.pdf",
+         filename        = "figures/heatmap_top50.pdf",
          width           = 8,
          height          = 10)
-cat("Saved volcano_plot.pdf and heatmap_top50.pdf\n")
+
 ```
 
 ### Step 8: Multi-Factor Design and Interaction Terms
@@ -461,8 +443,8 @@ res_reloaded <- results(dds_loaded, contrast = c("condition", "treated", "contro
 | `deseq2_significant.csv` | Filtered results: padj < 0.05 and |LFC| > 1 |
 | `pca_plot.pdf` | PCA of variance-stabilized counts; used to check batch structure and outliers |
 | `dispersion_plot.pdf` | Gene-wise vs. fitted dispersions; should show tight cloud around trend |
-| `volcano_plot.pdf` | Volcano plot with significance and LFC thresholds labeled |
-| `heatmap_top50.pdf` | Hierarchically clustered heatmap of top 50 DE genes |
+| `figures/volcano_plot.pdf` | Volcano plot with significance and LFC thresholds labeled |
+| `figures/heatmap_top50.pdf` | Hierarchically clustered heatmap of top 50 DE genes |
 | `gsea_ranked_list.rnk` | Pre-ranked gene list for pathway enrichment (fgsea/gseapy) |
 | `dds_fitted.rds` | Serialized DESeqDataSet for checkpoint/resume |
 
@@ -478,7 +460,6 @@ res_reloaded <- results(dds_loaded, contrast = c("condition", "treated", "contro
 | `apeglm` fails with convergence warning | Extreme LFC estimates (sparse data or complete separation) | Switch to `type = "ashr"` which is more robust to these cases |
 | Very large size factors (> 5) | Extremely different library sizes, or normalized counts accidentally used | Check `colSums(counts(dds))`; ensure input is raw integer counts from aligner/counter |
 | Dispersion plot shows outlier cloud far from trend | Noisy or failed libraries; incorrect metadata grouping | Examine PCA; remove outlier samples; check that `design` formula matches biological groups |
-| Volcano plot: no labeled points | `EnhancedVolcano` defaults label too few genes | Adjust `pCutoff` and `FCcutoff`; or set `selectLab = rownames(sig_genes)[1:20]` |
 
 ## References
 

--- a/skills/genomics-bioinformatics/rnaseq/gseapy-gene-enrichment/SKILL.md
+++ b/skills/genomics-bioinformatics/rnaseq/gseapy-gene-enrichment/SKILL.md
@@ -19,6 +19,7 @@ GSEApy provides Python implementations of GSEA and over-representation analysis 
 - Generating publication-ready enrichment dot plots and GSEA running-score plots
 - Use **GSEA Java application** for the official GUI-based analysis with full GSEA desktop interface
 - Use **fgsea** (R) as an alternative with fast permutation-based p-values; GSEApy is preferred for Python-native pipelines
+- Use **omics-plotting** SKILL after DE and for publication-quality plots of gsea results
 
 ## Prerequisites
 
@@ -144,40 +145,30 @@ print(sig.sort_values("NES", ascending=False)[["Term", "NES", "NOM p-val", "FDR 
 
 ### Step 4: Plot GSEA Running Score
 
-Visualize the enrichment score curve for a specific gene set.
+The running enrichment-score curve is GSEApy-specific — draw it with `gseaplot`. (omics-plotting covers the GSEA bar/dot summary plots instead, see Step 5.)
 
 ```python
-import gseapy as gp
-from gseapy.plot import gseaplot
-import matplotlib.pyplot as plt
+from gseapy import gseaplot
 
-# Re-use pre_res from Step 3 (or load saved results)
-# Select the top enriched gene set
+# pre_res: prerank result from Step 3
 top_term = pre_res.res2d.sort_values("NES", ascending=False).index[0]
-print(f"Top enriched gene set: {top_term}")
-
-# Plot running enrichment score
-ax = gseaplot(
+gseaplot(
     rank_metric=pre_res.ranking,
     term=top_term,
     **pre_res.results[top_term],
-    ofname="gsea_results/top_geneset_enrichment.pdf",
+    ofname="figures/gsea_running_score.png",
 )
-plt.tight_layout()
-plt.savefig("gsea_enrichment_plot.png", dpi=150)
-print("Saved: gsea_enrichment_plot.png")
+print(f"Saved figures/gsea_running_score.png ({top_term})")
 ```
 
 ### Step 5: Enrichment Dot Plot for Multiple Terms
 
-Generate a dot plot showing enrichment significance and gene ratio across top pathways.
+Run ORA, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "GSEA dot plot" recipe** on the exported table (→ `figures/enrichment_dotplot.png`). Map GSEApy's `Overlap` column to the recipe's `GeneRatio`.
 
 ```python
 import gseapy as gp
-import matplotlib.pyplot as plt
-from gseapy.plot import dotplot
 
-# Run ORA and plot results
+# enr.results is the enrichment table: Term, Overlap, Adjusted P-value, Genes, ...
 enr = gp.enrichr(
     gene_list=["TP53", "BRCA1", "CDK2", "CCND1", "MYC", "EGFR",
                "KRAS", "PTEN", "RB1", "AKT1", "PIK3CA", "MDM2",
@@ -187,22 +178,9 @@ enr = gp.enrichr(
     outdir=None,
     cutoff=0.05,
 )
-
-# Dot plot: x=gene ratio, size=-log10(p), color=adjusted p-value
-ax = dotplot(
-    enr.results,
-    column="Adjusted P-value",
-    x="Gene_set",
-    title="KEGG Enrichment",
-    cmap="viridis_r",
-    size=10,
-    top_term=15,
-    figsize=(6, 8),
-    ofname="enrichment_dotplot.pdf",
-)
-plt.tight_layout()
-plt.savefig("enrichment_dotplot.png", dpi=150, bbox_inches="tight")
-print("Saved: enrichment_dotplot.png")
+enr.results.to_csv("enrichment.csv", index=False)
+print(f"ORA terms: {len(enr.results)} -> enrichment.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "GSEA dot plot" recipe.
 ```
 
 ### Step 6: Integrate with DESeq2 / scanpy Output

--- a/skills/genomics-bioinformatics/rnaseq/pydeseq2-differential-expression/SKILL.md
+++ b/skills/genomics-bioinformatics/rnaseq/pydeseq2-differential-expression/SKILL.md
@@ -16,7 +16,7 @@ PyDESeq2 is a Python reimplementation of the R DESeq2 package for differential g
 - Performing two-group comparisons (e.g., treated vs control) with proper statistical testing
 - Running multi-factor designs that account for batch effects or covariates (e.g., `~batch + condition`)
 - Applying log2 fold change shrinkage (apeGLM) for ranking and visualization
-- Generating volcano plots, MA plots, and heatmaps from differential expression results
+- Use `omics-plotting` SKILL after DE for publication-quality plots of differential expression results
 - Converting R-based DESeq2 workflows to a pure Python environment
 - Integrating DE analysis into larger Python bioinformatics pipelines (e.g., with scanpy, pandas)
 - Use **DESeq2** (R/Bioconductor) or **edgeR** instead for the reference R implementations with the broadest method support and community validation
@@ -168,57 +168,24 @@ print("Results exported to CSV files")
 
 ### Step 7: Visualization — Volcano Plot
 
+Prepare the DEG table, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Volcano" recipe** on the exported CSV (→ `figures/volcano_plot.png`).
+
 ```python
-import matplotlib.pyplot as plt
-import numpy as np
-
-fig, ax = plt.subplots(figsize=(10, 7))
-res = results.dropna(subset=["padj"]).copy()
-res["-log10_padj"] = -np.log10(res.padj)
-
-# Color categories
-is_sig = (res.padj < 0.05) & (res.log2FoldChange.abs() > 1.0)
-is_up = is_sig & (res.log2FoldChange > 0)
-is_down = is_sig & (res.log2FoldChange < 0)
-
-ax.scatter(res.loc[~is_sig, "log2FoldChange"], res.loc[~is_sig, "-log10_padj"],
-           c="grey", alpha=0.3, s=8, label="Not significant")
-ax.scatter(res.loc[is_up, "log2FoldChange"], res.loc[is_up, "-log10_padj"],
-           c="firebrick", alpha=0.6, s=12, label=f"Up ({is_up.sum()})")
-ax.scatter(res.loc[is_down, "log2FoldChange"], res.loc[is_down, "-log10_padj"],
-           c="steelblue", alpha=0.6, s=12, label=f"Down ({is_down.sum()})")
-
-ax.axhline(-np.log10(0.05), ls="--", c="black", alpha=0.4)
-ax.axvline(-1, ls="--", c="black", alpha=0.4)
-ax.axvline(1, ls="--", c="black", alpha=0.4)
-ax.set_xlabel("Log2 Fold Change")
-ax.set_ylabel("-Log10(Adjusted P-value)")
-ax.set_title("Volcano Plot — Treated vs Control")
-ax.legend()
-plt.tight_layout()
-plt.savefig("volcano_plot.png", dpi=300)
-print("Saved volcano_plot.png")
+# Volcano input = log2FoldChange vs padj; saved in Step 6 as deseq2_all_results.csv
+volcano_input = results[["log2FoldChange", "padj"]].dropna()
+print(f"Volcano input: {len(volcano_input)} genes -> deseq2_all_results.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Volcano" recipe.
 ```
 
 ### Step 8: Visualization — MA Plot
 
+Prepare the DEG table, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "MA plot" recipe** on the exported CSV (→ `figures/ma_plot.png`).
+
 ```python
-fig, ax = plt.subplots(figsize=(10, 7))
-
-ax.scatter(np.log10(res.loc[~is_sig, "baseMean"] + 1),
-           res.loc[~is_sig, "log2FoldChange"],
-           c="grey", alpha=0.3, s=8)
-ax.scatter(np.log10(res.loc[is_sig, "baseMean"] + 1),
-           res.loc[is_sig, "log2FoldChange"],
-           c="firebrick", alpha=0.6, s=12)
-
-ax.axhline(0, ls="--", c="black", alpha=0.5)
-ax.set_xlabel("Log10(Mean Normalized Count + 1)")
-ax.set_ylabel("Log2 Fold Change")
-ax.set_title("MA Plot")
-plt.tight_layout()
-plt.savefig("ma_plot.png", dpi=300)
-print("Saved ma_plot.png")
+# MA input = log2FoldChange vs mean normalized count (baseMean); from deseq2_all_results.csv
+ma_input = results[["baseMean", "log2FoldChange", "padj"]].dropna(subset=["padj"])
+print(f"MA input: {len(ma_input)} genes -> deseq2_all_results.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "MA plot" recipe.
 ```
 
 ## Key Parameters
@@ -332,9 +299,9 @@ with open("dds_fitted.pkl", "rb") as f:
 - `deseq2_significant.csv` — Filtered results (padj < 0.05 and |LFC| > 1)
 - `deseq2_upregulated.csv` — Significant upregulated genes sorted by padj
 - `deseq2_downregulated.csv` — Significant downregulated genes sorted by padj
-- `volcano_plot.png` — Volcano plot with significance and fold change thresholds
-- `ma_plot.png` — MA plot showing fold change vs mean expression
-- `qc_diagnostics.png` — P-value distribution and dispersion plot
+- `figures/volcano_plot.png` — Volcano plot with significance and fold change thresholds
+- `figures/ma_plot.png` — MA plot showing fold change vs mean expression
+- `figures/qc_diagnostics.png` — P-value distribution and dispersion plot
 
 ## Troubleshooting
 

--- a/skills/genomics-bioinformatics/single-cell/celltypist-cell-annotation/SKILL.md
+++ b/skills/genomics-bioinformatics/single-cell/celltypist-cell-annotation/SKILL.md
@@ -18,6 +18,7 @@ CellTypist is an automated cell type classifier for single-cell RNA-seq data bui
 - Comparing annotation results across multiple tissue-specific models to determine the most biologically relevant reference
 - Training a custom CellTypist model from a labeled reference dataset for a tissue or species not covered by pre-built models
 - Quantifying annotation confidence to flag low-certainty cells (confidence score < 0.5) for manual review or exclusion
+- Use **omics-plotting** SKILL for generic result-table figures; UMAP/dotplot annotation views use scanpy `sc.pl.*`
 - Use **scVI/scANVI** (scvi-tools-single-cell) instead when you need probabilistic label transfer with batch correction and uncertainty quantification via a variational autoencoder
 - Use **popV** (popv-cell-annotation) instead when you want ensemble consensus from 10+ methods including deep learning and KNN-based approaches
 

--- a/skills/genomics-bioinformatics/single-cell/harmony-batch-correction/SKILL.md
+++ b/skills/genomics-bioinformatics/single-cell/harmony-batch-correction/SKILL.md
@@ -17,6 +17,7 @@ Harmony is a fast, scalable algorithm for batch integration in single-cell data.
 - Performing fast, scalable batch correction on datasets with millions of cells where deep generative model training would be prohibitively slow
 - Correcting for multiple confounding variables simultaneously (batch, donor, sequencing platform, tissue processing protocol)
 - Preparing a corrected embedding for UMAP visualization, Leiden clustering, or label transfer without modifying the gene expression count matrix
+- Use **omics-plotting** SKILL for generic result-table figures; batch-evaluation UMAPs use scanpy `sc.pl.*`
 - Use **scVI/scvi-tools** instead when you need probabilistic batch correction with a variational autoencoder (deep learning), differential expression with uncertainty estimates, or multi-modal integration (RNA + protein)
 - Use **BBKNN** instead when you want graph-based integration that avoids constructing a corrected embedding altogether and directly builds a cross-batch nearest-neighbor graph
 - Use **Seurat Integration / CCA** (R) instead when you are already in a Seurat workflow and prefer anchor-based integration methods

--- a/skills/genomics-bioinformatics/single-cell/popv-cell-annotation/SKILL.md
+++ b/skills/genomics-bioinformatics/single-cell/popv-cell-annotation/SKILL.md
@@ -17,6 +17,7 @@ popV (Population Voting for single-cell annotation) annotates a query scRNA-seq 
 - Benchmarking annotation reliability by comparing per-method labels to detect systematic disagreements
 - Annotating large atlas datasets (>100k cells) where batch effects between reference and query are substantial
 - Producing annotation for downstream analyses that require high-confidence labels (clinical data, regulatory submissions)
+- Use **omics-plotting** SKILL for confidence bar charts and method-agreement heatmaps from exported tables (UMAPs stay in scanpy `sc.pl.*`)
 - Use **CellTypist** (celltypist-cell-annotation) instead when speed matters and a pre-trained model matches your tissue; popV is slower because it trains multiple models on your reference
 - Use **scANVI** (scvi-tools-single-cell) instead when you need a single probabilistic deep generative model with formal uncertainty quantification and do not require the ensemble
 
@@ -353,22 +354,10 @@ popv_method_cols = [c for c in query_obs.columns if c.endswith("_popv") and
 print(f"\nLow-confidence cells sample (showing per-method labels):")
 print(low_conf[popv_method_cols + ["popv_prediction"]].head(10).to_string())
 
-# Visualize agreement distribution
-fig, axes = plt.subplots(1, 2, figsize=(14, 5))
-query_obs["popv_agreement"].hist(bins=20, ax=axes[0], color="steelblue", edgecolor="white")
-axes[0].axvline(0.8, color="red", linestyle="--", label="High-confidence threshold")
-axes[0].set_xlabel("Method Agreement Score")
-axes[0].set_ylabel("Cell Count")
-axes[0].set_title("popV Agreement Distribution")
-axes[0].legend()
-
-query_obs["confidence_tier"].value_counts().plot.bar(ax=axes[1], color="steelblue")
-axes[1].set_title("Cells by Confidence Tier")
-axes[1].set_xlabel("Confidence Tier")
-axes[1].set_ylabel("Cell Count")
-plt.tight_layout()
-plt.savefig("popv_confidence_distribution.png", dpi=150, bbox_inches="tight")
-print("Saved popv_confidence_distribution.png")
+# Save agreement + confidence-tier summaries; render the tier bar chart with the omics-plotting
+# SKILL (skills/data-visualization/omics-plotting/SKILL.md) "Box / Violin / Bar" recipe -> figures/popv_confidence_distribution.png
+query_obs[["popv_agreement", "confidence_tier"]].to_csv("popv_confidence.csv")
+print(query_obs["confidence_tier"].value_counts().to_string())
 ```
 
 ## Key Parameters
@@ -434,8 +423,6 @@ When to use: understanding where methods disagree to identify systematic biases 
 
 ```python
 import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
 
 query_mask = adata.obs["_dataset"] == "query"
 query_obs = adata[query_mask].obs.copy()
@@ -452,17 +439,10 @@ ct = pd.crosstab(
 )
 # Normalize rows
 ct_norm = ct.div(ct.sum(axis=1), axis=0)
-
-plt.figure(figsize=(12, 10))
-sns.heatmap(ct_norm, cmap="Blues", vmin=0, vmax=1,
-            xticklabels=True, yticklabels=True,
-            cbar_kws={"label": "Fraction of cells"})
-plt.title("knn_harmony vs scanvi label agreement")
-plt.xlabel("SCANVI label")
-plt.ylabel("KNN-Harmony label")
-plt.tight_layout()
-plt.savefig("popv_method_agreement_heatmap.png", dpi=150)
-print("Saved popv_method_agreement_heatmap.png")
+ct_norm.to_csv("popv_method_agreement.csv")
+print(f"Method agreement matrix: {ct_norm.shape} -> popv_method_agreement.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Expression heatmap" recipe (Blues, 0..1)
+# -> figures/popv_method_agreement_heatmap.png
 ```
 
 ### Recipe: Fast Annotation Without Deep Learning Methods

--- a/skills/genomics-bioinformatics/single-cell/scanpy-scrna-seq/SKILL.md
+++ b/skills/genomics-bioinformatics/single-cell/scanpy-scrna-seq/SKILL.md
@@ -21,6 +21,7 @@ Scanpy is a scalable Python toolkit for analyzing single-cell RNA-seq data built
 - Conducting trajectory inference and pseudotime analysis (PAGA, diffusion pseudotime)
 - Generating publication-quality single-cell plots (dot plots, heatmaps, stacked violins)
 - Comparing gene expression across experimental conditions within cell types
+- Use **omics-plotting** SKILL for generic figures (volcano/heatmap/bar/KM) from exported tables; single-cell views stay in scanpy `sc.pl.*`
 - Use **Seurat** (R/Bioconductor) instead for scRNA-seq analysis in an existing R workflow or when Seurat-specific assay types are required
 
 ## Prerequisites

--- a/skills/genomics-bioinformatics/variant/cnvkit-copy-number/SKILL.md
+++ b/skills/genomics-bioinformatics/variant/cnvkit-copy-number/SKILL.md
@@ -18,6 +18,7 @@ CNVkit detects somatic copy number variants (CNVs) from whole-exome sequencing (
 - Estimating tumor purity and ploidy for samples where purity is unknown, to interpret copy ratio calls
 - Generating SEG format copy number files for GISTIC2, cBioPortal, or IGV visualization
 - Identifying focal amplifications (e.g., ERBB2, MYC) or homozygous deletions (e.g., CDKN2A, RB1)
+- Use **omics-plotting** SKILL for generic coverage/log2-ratio figures from exported tables; genome-wide CNV views use `cnvkit.py scatter/diagram`
 - Use **GATK CNV** (`gatk DenoiseReadCounts` / `gatk ModelSegments`) instead for deep WGS cohorts with large matched panel-of-normals (PoN); CNVkit is better suited for targeted/exome data
 - Use **Control-FREEC** instead when you need allele-frequency-based B-allele fraction modeling alongside CNV calling
 
@@ -142,16 +143,10 @@ print(f"Antitarget bins: {len(antitarget_cov)}")
 print(f"Mean target depth: {target_cov['depth'].mean():.1f}×")
 print(f"Median target depth: {target_cov['depth'].median():.1f}×")
 
-# Check coverage distribution
-import matplotlib.pyplot as plt
-fig, ax = plt.subplots(figsize=(8, 4))
-target_cov["depth"].clip(upper=500).hist(bins=50, ax=ax, color="#2c6fad", alpha=0.7)
-ax.set_xlabel("Read depth")
-ax.set_ylabel("Bin count")
-ax.set_title("Target bin coverage distribution")
-plt.tight_layout()
-plt.savefig("coverage_distribution.png", dpi=150)
-print("Saved: coverage_distribution.png")
+# Export target-bin depths; render the coverage histogram with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`)
+# "Box / Violin / Bar" recipe (or a histogram) -> figures/coverage_distribution.png
+target_cov["depth"].clip(upper=500).to_csv("target_depths.csv", index=False)
+print("Saved: target_depths.csv")
 ```
 
 ### Step 3: Normalize and Correct Copy Ratios
@@ -317,45 +312,20 @@ echo "Plots saved: tumor-scatter.png, tumor-diagram.pdf, cohort_heatmap.pdf"
 ```
 
 ```python
-# Custom scatter plot with matplotlib highlighting specific genes
+# Extract a single chromosome's bins + segments for a custom log2-ratio scatter
 import cnvlib
-import matplotlib.pyplot as plt
-import numpy as np
 
 cnr = cnvlib.read("tumor.cnr")
 cns = cnvlib.read("tumor.cns")
 
-# Plot chr7 (EGFR locus) in detail
-fig, ax = plt.subplots(figsize=(12, 4))
-chrom = "chr7"
-cnr_chr = cnr.data[cnr.data["chromosome"] == chrom]
-cns_chr = cns.data[cns.data["chromosome"] == chrom]
-
-# Bin dots
-ax.scatter(cnr_chr["start"], cnr_chr["log2"],
-           s=3, alpha=0.3, color="#aaa", label="Bins")
-# Segment lines
-for _, seg in cns_chr.iterrows():
-    ax.hlines(seg["log2"], seg["start"], seg["end"],
-              colors=("#d32f2f" if seg["log2"] > 0.3 else
-                      "#1565c0" if seg["log2"] < -0.3 else "#666"),
-              lw=3, label="_nolegend_")
-
-# Mark EGFR
-egfr_start, egfr_end = 55_019_017, 55_211_628
-ax.axvspan(egfr_start, egfr_end, alpha=0.15, color="orange")
-ax.text((egfr_start + egfr_end) / 2, ax.get_ylim()[1] * 0.85,
-        "EGFR", ha="center", fontsize=9, color="darkorange")
-
-ax.axhline(0, color="black", lw=0.8, ls="--")
-ax.axhline(0.585, color="#d32f2f", lw=0.5, ls=":")   # gain threshold
-ax.axhline(-1.0, color="#1565c0", lw=0.5, ls=":")    # loss threshold
-ax.set_xlabel("Chromosome 7 position (bp)")
-ax.set_ylabel("Log2 copy ratio")
-ax.set_title(f"CNV Profile — {chrom}")
-plt.tight_layout()
-plt.savefig("chr7_cnv_scatter.png", dpi=150, bbox_inches="tight")
-print("Saved: chr7_cnv_scatter.png")
+chrom = "chr7"   # EGFR locus
+cnr_chr = cnr.data[cnr.data["chromosome"] == chrom][["start", "log2"]]
+cns_chr = cns.data[cns.data["chromosome"] == chrom][["start", "end", "log2"]]
+cnr_chr.to_csv(f"{chrom}_bins.csv", index=False)
+cns_chr.to_csv(f"{chrom}_segments.csv", index=False)
+print(f"{chrom}: {len(cnr_chr)} bins, {len(cns_chr)} segments")
+# Render a per-chromosome log2 scatter with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) scatter recipe
+# (overlay segment hlines and a gene-locus axvspan for EGFR) -> figures/chr7_cnv_scatter.png
 ```
 
 ### Step 7: Estimate Tumor Purity and Ploidy

--- a/skills/genomics-bioinformatics/variant/plink2-gwas-analysis/SKILL.md
+++ b/skills/genomics-bioinformatics/variant/plink2-gwas-analysis/SKILL.md
@@ -18,6 +18,7 @@ PLINK2 is the high-performance successor to PLINK 1.9, designed for genome-wide 
 - Running PCA on genotype data to identify population stratification
 - Converting between PLINK binary, VCF, and BGEN formats
 - Filtering variants by MAF, HWE, missingness, or INFO score in VCF/imputed data
+- Use **omics-plotting** SKILL to render Manhattan and QQ plots from the association results
 - Use **regenie** or **SAIGE** instead for biobank-scale GWAS (>100k samples) requiring mixed model association to control for population structure
 - Use **VCFtools** as an alternative for VCF-specific population genetics statistics
 
@@ -201,47 +202,23 @@ wc -l results/gwas_qt.*.glm.linear
 
 ### Step 6: Plot Manhattan and QQ Plots
 
-Visualize GWAS results with Python.
+Prepare the association results as a CHR/BP/P table, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Manhattan" and "QQ plot" recipes** on the exported CSV (→ `figures/manhattan.png`, `figures/qq.png`).
 
 ```python
 import pandas as pd
-import numpy as np
-import matplotlib.pyplot as plt
-from scipy.stats import chi2
 
-# Load GWAS results (PLINK2 linear output)
+# Load GWAS results (PLINK2 linear output) as a CHR/BP/P table for plotting
 df = pd.read_csv("results/gwas_qt.PHENO1.glm.linear", sep="\t",
                  usecols=["#CHROM", "POS", "ID", "P"])
-df.columns = ["CHR", "POS", "SNP", "P"]
+df.columns = ["CHR", "BP", "SNP", "P"]
 df = df.dropna(subset=["P"])
 df["P"] = pd.to_numeric(df["P"], errors="coerce")
 df = df[df["P"] > 0].copy()
-df["-log10P"] = -np.log10(df["P"])
+df.to_csv("gwas.csv", index=False)
 
 print(f"Variants: {len(df)}")
 print(f"Genome-wide significant (p<5e-8): {(df['P'] < 5e-8).sum()}")
-
-# Manhattan plot
-fig, ax = plt.subplots(figsize=(14, 4))
-colors = plt.cm.Set1.colors
-chrom_pos = 0
-ticks = []
-for chrom, group in df.groupby("CHR", sort=False):
-    col = colors[int(chrom) % 2] if str(chrom).isdigit() else "gray"
-    ax.scatter(group["POS"] + chrom_pos, group["-log10P"],
-               c=[col], s=2, alpha=0.7)
-    ticks.append((chrom_pos + group["POS"].mean(), str(chrom)))
-    chrom_pos += group["POS"].max() + 1e7
-
-ax.axhline(-np.log10(5e-8), color="red", linestyle="--", lw=1, label="p=5×10⁻⁸")
-ax.set_xticks([t[0] for t in ticks[::2]])
-ax.set_xticklabels([t[1] for t in ticks[::2]], fontsize=6)
-ax.set_xlabel("Chromosome")
-ax.set_ylabel("-log₁₀(p)")
-ax.set_title("GWAS Manhattan Plot")
-plt.tight_layout()
-plt.savefig("manhattan.png", dpi=150)
-print("Saved: manhattan.png")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Manhattan" and "QQ plot" recipes (input columns CHR, BP, P).
 ```
 
 ## Key Parameters

--- a/skills/genomics-bioinformatics/variant/snpeff-variant-annotation/SKILL.md
+++ b/skills/genomics-bioinformatics/variant/snpeff-variant-annotation/SKILL.md
@@ -17,6 +17,7 @@ SnpEff annotates variants in VCF files by predicting their functional consequenc
 - Adding ClinVar pathogenicity classifications and dbSNP rsIDs to a variant set for cross-study comparison or clinical reporting
 - Extracting structured, tab-delimited fields (gene, protein change, AF, ClinSig) from annotated VCFs into pandas DataFrames for statistical analysis
 - Identifying candidate de novo variants in trio analysis by combining allele frequency thresholds, impact filters, and parent VCF exclusion
+- Use **omics-plotting** SKILL to render consequence/impact bar charts from the annotated variant tables
 - Use **ANNOVAR** instead when comprehensive annotation from multiple databases (gnomAD, CADD, SpliceAI) in a single run is required
 - Use **Ensembl VEP** instead when REST API access or VEP-specific plugins (CADD, LOFTEE, SpliceRegion) are needed
 
@@ -242,13 +243,9 @@ print(df["impact"].value_counts())
 
 ### Step 7: Summary Statistics and Consequence Visualization
 
-Generate a bar chart of variant consequences and a count summary by impact tier to prioritize review.
+Summarize variant consequences by impact tier, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Box / Violin / Bar" recipe** on the exported tables (→ `figures/variant_consequence_summary.png`).
 
 ```python
-import matplotlib.pyplot as plt
-import matplotlib.ticker as mticker
-import seaborn as sns
-
 # Consequence counts by impact (df from Step 6)
 impact_order = ["HIGH", "MODERATE", "LOW", "MODIFIER"]
 impact_counts = df["impact"].value_counts().reindex(impact_order, fill_value=0)
@@ -262,30 +259,12 @@ top_effects = (
     .head(15)
 )
 
-fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+# Save summary tables; render bar charts with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Box / Violin / Bar" recipe.
+impact_counts.rename("count").to_csv("variant_impact_counts.csv")
+top_effects.rename("count").to_csv("variant_top_effects.csv")
+print(impact_counts.to_string())
 
-# Left: impact tier counts
-impact_counts.plot(kind="bar", ax=axes[0],
-                   color=["#d62728", "#ff7f0e", "#2ca02c", "#aec7e8"],
-                   edgecolor="black")
-axes[0].set_title("Variant Counts by Impact Tier", fontsize=13)
-axes[0].set_xlabel("Impact")
-axes[0].set_ylabel("Count")
-axes[0].yaxis.set_major_formatter(mticker.FuncFormatter(lambda x, _: f"{int(x):,}"))
-axes[0].tick_params(axis="x", rotation=0)
-
-# Right: top HIGH/MODERATE effects
-top_effects.plot(kind="barh", ax=axes[1], color="#1f77b4", edgecolor="black")
-axes[1].set_title("Top HIGH/MODERATE Variant Effects", fontsize=13)
-axes[1].set_xlabel("Count")
-axes[1].invert_yaxis()
-
-plt.tight_layout()
-plt.savefig("variant_consequence_summary.png", dpi=150, bbox_inches="tight")
-plt.show()
-print("Saved: variant_consequence_summary.png")
-
-# Print HIGH-impact gene table
+# HIGH-impact gene table
 high_genes = (
     df[df["impact"] == "HIGH"]["gene"]
     .value_counts()

--- a/skills/proteomics-protein-engineering/maxquant-proteomics/SKILL.md
+++ b/skills/proteomics-protein-engineering/maxquant-proteomics/SKILL.md
@@ -20,6 +20,7 @@ MaxQuant is the community-standard software for label-free quantification (LFQ) 
 - Generating publication-quality volcano plots and GO enrichment from proteomics data in a reproducible Python workflow
 - Use **Proteome Discoverer** instead when working with Thermo raw files requiring instrument-native processing or Sequest HT
 - Use **FragPipe/MSFragger** instead for GPU-accelerated database search (3–10× faster) or when processing DIA (data-independent acquisition) data
+- Use **omics-plotting** SKILL after differential abundance analysis or GSEA for publication-quality plots
 
 ## Prerequisites
 
@@ -346,64 +347,15 @@ print(results[results["significant"]].head(10))
 
 ### Step 7: Volcano Plot Visualization
 
-Generate a publication-quality volcano plot showing log2 fold change vs. -log10(p-value) with significance thresholds highlighted.
+> **Plotting:** compute the DEG table, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Volcano" recipe** on the exported CSV (→ `figures/volcano_plot.png`).
 
 ```python
-import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
-
-def plot_volcano(results: pd.DataFrame,
-                 gene_names: pd.Series,
-                 fc_threshold: float = 1.0,
-                 pval_threshold: float = 0.05,
-                 top_n_labels: int = 10,
-                 save_path: str = "volcano_plot.pdf") -> None:
-    """Volcano plot: log2FC vs -log10(adjusted p-value)."""
-    df = results.copy()
-    df["gene"] = gene_names.reindex(df.index).fillna("Unknown")
-    df["-log10p"] = -np.log10(df["padj"].clip(lower=1e-300))
-
-    # Classify regulation
-    df["regulation"] = "ns"
-    df.loc[(df["log2FC"] >  fc_threshold) & (df["padj"] < pval_threshold), "regulation"] = "up"
-    df.loc[(df["log2FC"] < -fc_threshold) & (df["padj"] < pval_threshold), "regulation"] = "down"
-
-    color_map = {"up": "#D62728", "down": "#1F77B4", "ns": "#AAAAAA"}
-
-    fig, ax = plt.subplots(figsize=(7, 6))
-    for reg, grp in df.groupby("regulation"):
-        ax.scatter(grp["log2FC"], grp["-log10p"],
-                   c=color_map[reg], s=12, alpha=0.7, linewidths=0, label=reg)
-
-    # Threshold lines
-    ax.axhline(-np.log10(pval_threshold), color="k", lw=0.8, ls="--", alpha=0.5)
-    ax.axvline( fc_threshold,  color="k", lw=0.8, ls="--", alpha=0.5)
-    ax.axvline(-fc_threshold, color="k", lw=0.8, ls="--", alpha=0.5)
-
-    # Label top significant proteins by -log10p
-    top = df[df["regulation"] != "ns"].nlargest(top_n_labels, "-log10p")
-    for _, row in top.iterrows():
-        ax.text(row["log2FC"], row["-log10p"] + 0.1, row["gene"],
-                fontsize=6, ha="center", va="bottom")
-
-    # Counts in legend
-    up_n   = (df["regulation"] == "up").sum()
-    down_n = (df["regulation"] == "down").sum()
-    patches = [
-        mpatches.Patch(color="#D62728", label=f"Up ({up_n})"),
-        mpatches.Patch(color="#1F77B4", label=f"Down ({down_n})"),
-        mpatches.Patch(color="#AAAAAA", label="ns"),
-    ]
-    ax.legend(handles=patches, fontsize=8, frameon=False)
-    ax.set_xlabel("log₂ Fold Change (treat / ctrl)", fontsize=11)
-    ax.set_ylabel("-log₁₀(adjusted p-value)", fontsize=11)
-    ax.set_title("Differential Protein Abundance", fontsize=12)
-    plt.tight_layout()
-    plt.savefig(save_path, dpi=300, bbox_inches="tight")
-    plt.show()
-    print(f"Saved: {save_path}")
-
-plot_volcano(results, pg["Gene names"])
+# Volcano input: log2FC vs padj + protein labels; render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Volcano" recipe.
+volcano_df = results[["log2FC", "padj"]].copy()
+volcano_df["gene"] = pg["Gene names"].reindex(results.index)
+volcano_df.dropna(subset=["log2FC", "padj"]).to_csv("volcano_input.csv")
+print(f"Volcano input: {int(volcano_df['padj'].notna().sum())} proteins -> volcano_input.csv")
+# -> figures/volcano_plot.png via omics-plotting (map log2FC -> log2FoldChange)
 ```
 
 ### Step 8: GO/Pathway Enrichment of Significant Proteins
@@ -538,46 +490,30 @@ print(log2_ratios.describe().round(3))
 
 ### Recipe: Hierarchical Clustering Heatmap
 
-When to use: visualizing patterns across all significant proteins simultaneously.
+When to use: visualizing patterns across all significant proteins simultaneously. Compute the z-scored matrix below, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its "Clustered expression heatmap" recipe** (→ `figures/heatmap.pdf`).
 
 ```python
-import seaborn as sns
-import matplotlib.pyplot as plt
+import pandas as pd
 
-def plot_heatmap(lfq_imputed: pd.DataFrame,
-                 results: pd.DataFrame,
-                 gene_names: pd.Series,
-                 top_n: int = 50,
-                 save_path: str = "heatmap.pdf") -> None:
-    """Hierarchical clustering heatmap of top significant proteins."""
-    sig_proteins = results[results["significant"]].nlargest(top_n, "-log10p" if "-log10p" in results else "padj").index
-    # Recalculate if needed
+def prep_heatmap_matrix(lfq_imputed: pd.DataFrame,
+                        results: pd.DataFrame,
+                        gene_names: pd.Series,
+                        top_n: int = 50,
+                        out_path: str = "heatmap_matrix.csv") -> pd.DataFrame:
+    """Z-scored expression matrix of the top significant proteins, for the omics-plotting heatmap."""
     sig_proteins = results[results["significant"]].nsmallest(top_n, "padj").index
-
     heatmap_data = lfq_imputed.loc[sig_proteins].copy()
     heatmap_data.index = gene_names.reindex(sig_proteins).fillna(sig_proteins)
-
-    # Z-score per row for visualization
+    # Z-score per row
     heatmap_z = heatmap_data.subtract(heatmap_data.mean(axis=1), axis=0).divide(
         heatmap_data.std(axis=1).replace(0, 1), axis=0
     )
+    heatmap_z.to_csv(out_path)
+    return heatmap_z
 
-    g = sns.clustermap(
-        heatmap_z,
-        cmap="RdBu_r",
-        center=0,
-        vmin=-2.5, vmax=2.5,
-        figsize=(8, 10),
-        yticklabels=True,
-        xticklabels=True,
-        dendrogram_ratio=(0.15, 0.1),
-        cbar_kws={"label": "Z-score (log₂ LFQ)"},
-    )
-    g.ax_heatmap.set_yticklabels(g.ax_heatmap.get_yticklabels(), fontsize=6)
-    plt.savefig(save_path, dpi=300, bbox_inches="tight")
-    print(f"Saved: {save_path}")
-
-plot_heatmap(lfq_imputed, results, pg["Gene names"])
+mat = prep_heatmap_matrix(lfq_imputed, results, pg["Gene names"])
+print(f"Heatmap matrix: {mat.shape} -> heatmap_matrix.csv")
+# Render with the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) "Clustered expression heatmap" recipe -> figures/heatmap.pdf
 ```
 
 ### Recipe: STRING-db Network Enrichment for Significant Proteins

--- a/skills/systems-biology-multiomics/cellchat-cell-communication/SKILL.md
+++ b/skills/systems-biology-multiomics/cellchat-cell-communication/SKILL.md
@@ -17,6 +17,7 @@ CellChat is an R package that infers and visualizes intercellular signaling netw
 - Comparing intercellular signaling networks between two conditions (e.g., healthy vs. diseased, treatment vs. control) to find rewired or lost communication
 - Discovering pathway-level signaling programs (e.g., MHC-II, COLLAGEN, VEGF) enriched in a particular cell-cell interaction
 - Prioritizing targets for perturbation experiments by ranking signaling pathways by their aggregate communication strength or network centrality
+- Use **omics-plotting** SKILL (Python) for generic figures from exported tables; network chord/heatmap/bubble views use CellChat's R `netVisual_*`
 - Use **liana** (Python/R) instead when you want a pure-Python workflow or a consensus ranking across multiple ligand-receptor databases (CellChat, CellPhoneDB, Connectome, NicheNet)
 - Use **NicheNet** (R) instead when you need ligand-to-target gene regulatory inference — predicting which ligands from sender cells regulate which target genes in receiver cells
 

--- a/skills/systems-biology-multiomics/mofaplus-multi-omics/SKILL.md
+++ b/skills/systems-biology-multiomics/mofaplus-multi-omics/SKILL.md
@@ -18,6 +18,7 @@ MOFA+ (Multi-Omics Factor Analysis v2) is an unsupervised statistical framework 
 - Reducing multi-omics dimensionality before clustering, trajectory inference, or survival modeling
 - Discovering which genomic features (genes, peaks, proteins) drive each factor via sparse loadings
 - Annotating latent factors by correlating factor scores with sample metadata (age, stage, treatment response)
+- Use **omics-plotting** SKILL after training for publication-quality factor scatter and loading heatmaps
 - Use **scVI / MultiVI** (scverse) instead when you need deep generative batch correction across modalities with explicit latent space inference and VAE architecture
 - Use **LIGER** instead when your primary goal is integrating datasets across technologies (e.g., snRNA-seq + snATAC-seq) with shared and dataset-specific factors via iNMF
 
@@ -263,54 +264,25 @@ for fc in factor_cols[:5]:
 
 ### Step 7: Visualize Factors — Scatter Plots and Feature Heatmaps
 
-Plot factor score scatter plots colored by metadata, and heatmaps of the top-weighted features (loadings) per factor to understand what each factor captures.
+Extract the feature weights (loadings) per factor here, then **read `skills/data-visualization/omics-plotting/SKILL.md` and follow its recipes** so figures share one consistent style: `factors_meta` (from Step 6) → *factor scatter* (→ `figures/mofa_factor_scatter.png`); `weights_rna` → *expression heatmap* of the top ± loadings (→ `figures/mofa_rna_weights_heatmap.png`).
 
 ```python
 def load_mofa_weights(model_path, view_name):
     """Load feature weights (W) for a specific view. Returns DataFrame (features x factors)."""
     with h5py.File(model_path, "r") as f:
-        views = [v.decode() for v in f["views"]["views"][:]]
-        view_idx = views.index(view_name)
-        # Weights stored per view as (n_factors, n_features)
-        w = f["expectations"]["W"][view_name][:]
+        w = f["expectations"]["W"][view_name][:]   # (n_factors, n_features)
         features = [ft.decode() for ft in f["features"][view_name][:]]
         n_factors = w.shape[0]
         df = pd.DataFrame(w.T, index=features,
                           columns=[f"Factor{i+1}" for i in range(n_factors)])
     return df
 
-# --- Factor scatter plot ---
-fig, axes = plt.subplots(1, 2, figsize=(12, 5))
-
-for ax, (fx, fy) in zip(axes, [("Factor1", "Factor2"), ("Factor1", "Factor3")]):
-    for cond, grp in factors_meta.groupby("condition"):
-        ax.scatter(grp[fx], grp[fy], label=cond, alpha=0.6, s=20)
-    ax.set_xlabel(fx)
-    ax.set_ylabel(fy)
-    ax.legend(title="Condition")
-    ax.set_title(f"{fx} vs {fy}")
-
-plt.tight_layout()
-plt.savefig("mofa_factor_scatter.png", dpi=200)
-print("Saved mofa_factor_scatter.png")
-
-# --- Top-loading heatmap for RNA view ---
 weights_rna = load_mofa_weights("mofa_model.hdf5", "RNA")
-top_n = 20
-top_features = []
-for fc in [f"Factor{i+1}" for i in range(min(5, weights_rna.shape[1]))]:
-    top_pos = weights_rna[fc].nlargest(top_n // 2).index.tolist()
-    top_neg = weights_rna[fc].nsmallest(top_n // 2).index.tolist()
-    top_features.extend(top_pos + top_neg)
-top_features = list(dict.fromkeys(top_features))  # unique, preserve order
+print(f"RNA weights: {weights_rna.shape} (features x factors)")
 
-fig, ax = plt.subplots(figsize=(8, max(6, len(top_features) * 0.3)))
-sns.heatmap(weights_rna.loc[top_features, [f"Factor{i+1}" for i in range(min(5, weights_rna.shape[1]))]],
-            cmap="RdBu_r", center=0, ax=ax, yticklabels=True)
-ax.set_title("Top RNA Feature Weights per Factor")
-plt.tight_layout()
-plt.savefig("mofa_rna_weights_heatmap.png", dpi=200)
-print("Saved mofa_rna_weights_heatmap.png")
+# Plot inputs are ready; use the omics-plotting SKILL (`skills/data-visualization/omics-plotting/SKILL.md`) to render:
+#   factors_meta -> "factor scatter"  -> figures/mofa_factor_scatter.png
+#   weights_rna  -> loading heatmap   -> figures/mofa_rna_weights_heatmap.png
 ```
 
 ### Step 8: Downstream — Cluster Cells by Factor Scores and Enrichment
@@ -493,8 +465,8 @@ print("\nSaved mofa_factor_annotation.csv")
 |--------|-------------|
 | `mofa_model.hdf5` | Trained MOFA+ model — factor scores, weights, ELBO trace, variance explained |
 | `mofa_variance_explained.png` | Heatmap of R2 (%) per factor per view; primary diagnostic for factor selection |
-| `mofa_factor_scatter.png` | Scatter plots of Factor1 vs Factor2/3 colored by metadata (condition, patient) |
-| `mofa_rna_weights_heatmap.png` | Heatmap of top RNA feature weights across the first 5 factors |
+| `figures/mofa_factor_scatter.png` | Scatter plots of Factor1 vs Factor2/3 colored by metadata (condition, patient); via omics-plotting |
+| `figures/mofa_rna_weights_heatmap.png` | Heatmap of top RNA feature weights across the first 5 factors; via omics-plotting |
 | `mofa_factor_scores.csv` | Table of per-cell factor scores (cells x factors) with cluster labels |
 | `mofa_factor_annotation.csv` | Factor annotation table: top positive/negative genes per factor |
 | Per-factor gene lists | Input for gseapy Enrichr or GSEA to identify enriched pathways per factor |

--- a/skills/systems-biology-multiomics/muon-multiomics-singlecell/SKILL.md
+++ b/skills/systems-biology-multiomics/muon-multiomics-singlecell/SKILL.md
@@ -19,6 +19,7 @@ muon is a Python framework for multi-modal single-cell data analysis that extend
 - Normalizing surface protein data with centered log-ratio (CLR) normalization
 - Performing cross-modal feature linkage (associating ATAC peaks with nearby gene expression)
 - Applying MOFA+ factor analysis across multiple omics layers within a unified container
+- Use **omics-plotting** SKILL for generic result-table figures; joint embeddings use scanpy/muon `sc.pl.*` / `mu.pl.*`
 - Use **scanpy-scrna-seq** instead when analyzing a single RNA-seq modality without any co-measured omics
 - Use **scvi-tools (MultiVI / totalVI)** when you need probabilistic deep generative batch correction across modalities
 

--- a/skills/systems-biology-multiomics/omics-analysis-guide/SKILL.md
+++ b/skills/systems-biology-multiomics/omics-analysis-guide/SKILL.md
@@ -328,6 +328,8 @@ Only then proceed to **Option 2: Use Standard Workflows**
 
 ### 2.5 Visualization
 
+**For all figures, read `skills/data-visualization/omics-plotting/SKILL.md` and follow its recipes** so every plot shares one publication-ready style. The two plots below map directly onto its recipes — the volcano onto "Volcano", the PCA onto "PCA / UMAP / t-SNE" — with results loaded from an exported CSV (keep computation and plotting in separate steps).
+
 **Volcano Plot**:
 - X-axis: Log2 fold change
 - Y-axis: -Log10 adjusted p-value
@@ -440,8 +442,7 @@ res <- results(dds, contrast=c("condition", "treatment", "control"))
 - Filter significant results (p_adj < 0.05)
 
 **Step 6**: Visualization
-- Create volcano plot
-- Create PCA plot for QC
+- Read `skills/data-visualization/omics-plotting/SKILL.md` and use its "Volcano" and "PCA / UMAP / t-SNE" recipes on the exported results/QC tables
 
 ---
 
@@ -513,6 +514,16 @@ res <- results(dds, contrast=c("condition", "treatment", "control"))
 7. **Treating Option 3 (custom analysis) as a shortcut.**
    *Problem*: Jumping straight to custom methods without first running standard workflows skips peer-reviewed validation and makes results harder to publish and reproduce.
    *How to avoid*: Document a clear justification for why Options 1 and 2 are inadequate before moving to Option 3, and validate any custom method on simulated or held-out data.
+
+## Related Skills
+
+Concrete SKILLs implementing the tiers above:
+
+- **omics-plotting** (`skills/data-visualization/omics-plotting/SKILL.md`) — publication-ready figures for every output here (volcano, MA, expression/correlation heatmap, GSEA bar/dot, PCA/UMAP, Kaplan–Meier, Manhattan/QQ/forest). Read it before writing any plotting code.
+- **deseq2-differential-expression** / **pydeseq2-differential-expression** — Option 1 RNA-seq differential expression (R and Python).
+- **gseapy-gene-enrichment** — GSEA / ORA functional enrichment on ranked DE results.
+- **maxquant-proteomics** — Option 1/2 proteomics quantification and differential abundance.
+- **mofaplus-multi-omics** — Option 3 multi-omics factor integration.
 
 ## References
 


### PR DESCRIPTION
## Summary

skills/data-visualization/omics-plotting/SKILL.md 스킬이 생기면서 기존 스킬에 plot visualization 중복되는 부분은 omics-plotting skill로 유도하여 전체적으로 통일감있는 figure생성을 하도록 유도한다. 이과정에서 omics-plotting에도 DNAseq관련 플랏이 몇 추가되었다.

수정된 코드: 

genomics-bioinformatics 15개 스킬 (3 RNA, 4 DNA, 4 scRNA, 4 database 분석)
proteomics-protein-engineering 1개 스킬 (maxquant)
systemas-biology-multiomics 3개 스킬 (muon, mofa+, cellchat)

간단 수정 :  
skills/data-visualization/multipanel/SKILL.md는 
 -> output 폴더명 plots/ -> figures/ 
skills/data-visualization/omics-plotting/SKILL.md 
 -> output 폴더명 plots/ -> figures/ 
 -> scatterplot (UMAP, PCA, scatter) 분리
 -> QQ, Manhattan, forest plot 추가

## Checklist

- [ ] `pixi run test` passes locally
- [ ] `registry.yaml` updated with the new entry
- [ ] Skill type is correctly set: pipeline / toolkit / database / guide
- [ ] `description` field is ≤ 1024 characters
- [ ] Frontmatter has `name`, `description`, `license`
- [ ] Required sections present in correct order (see `AGENTS.md`)
- [ ] Code blocks are runnable with sample data or clear placeholders
- [ ] Troubleshooting table has 5+ rows
- [ ] Key Parameters table has 5+ rows

## Skill(s) added or modified

List the skill paths, e.g. `skills/genomics-bioinformatics/salmon-rna-quantification/SKILL.md`
